### PR TITLE
feat(visionos): Loop HQ — multiplayer photoreal Salesforce Park

### DIFF
--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		DA17C13000000000000000B6 /* NIOSSH in Frameworks */ = {isa = PBXBuildFile; productRef = DA17C13000000000000000A6 /* NIOSSH */; };
 		DA17C14000000000000000D4 /* SwiftTerm in Frameworks */ = {isa = PBXBuildFile; productRef = DA17C14000000000000000C4 /* SwiftTerm */; };
 		DA17C15000000000000000F5 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = DA17C15000000000000000E5 /* Sparkle */; };
+		DA17C17000000000000000B4 /* GLTFKit2 in Frameworks */ = {isa = PBXBuildFile; productRef = DA17C17000000000000000A4 /* GLTFKit2 */; };
+		DA17C18000000000000000B4 /* DracoSwift in Frameworks */ = {isa = PBXBuildFile; productRef = DA17C18000000000000000A4 /* DracoSwift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -48,6 +50,7 @@
 		6A0903832CD69D9500E70D46 /* Loop.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Loop.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6B00010100000000DEADBEEF /* LoopMac.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LoopMac.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6C00020100000000DEADBEEF /* LoopVision.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LoopVision.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		6D00040100000000DEADBEEF /* LoopHQ.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LoopHQ.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -120,6 +123,13 @@
 				Info.plist,
 			);
 			target = 6C00020A00000000DEADBEEF /* LoopVision */;
+		};
+		6D00040600000000DEADBEEF /* Exceptions for "LoopHQ" folder in "LoopHQ" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 6D00040A00000000DEADBEEF /* LoopHQ */;
 		};
 		6C00020700000000DEADBEEF /* Exceptions for "LoopIOS" folder in "LoopVision" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
@@ -197,6 +207,14 @@
 			path = LoopVision;
 			sourceTree = "<group>";
 		};
+		6D00040500000000DEADBEEF /* LoopHQ */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				6D00040600000000DEADBEEF /* Exceptions for "LoopHQ" folder in "LoopHQ" target */,
+			);
+			path = LoopHQ;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -236,6 +254,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		6D00040300000000DEADBEEF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DA17C17000000000000000B4 /* GLTFKit2 in Frameworks */,
+				DA17C18000000000000000B4 /* DracoSwift in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -247,6 +274,7 @@
 				6B00010500000000DEADBEEF /* LoopMac */,
 				5EE7AAD32FB7A82B00062171 /* LoopShare */,
 				6C00020500000000DEADBEEF /* LoopVision */,
+				6D00040500000000DEADBEEF /* LoopHQ */,
 				6A0903842CD69D9500E70D46 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -258,6 +286,7 @@
 				6B00010100000000DEADBEEF /* LoopMac.app */,
 				5EE7AAD22FB7A82B00062171 /* LoopShare.appex */,
 				6C00020100000000DEADBEEF /* LoopVision.app */,
+				6D00040100000000DEADBEEF /* LoopHQ.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -365,6 +394,30 @@
 			productReference = 6C00020100000000DEADBEEF /* LoopVision.app */;
 			productType = "com.apple.product-type.application";
 		};
+		6D00040A00000000DEADBEEF /* LoopHQ */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6D00040800000000DEADBEEF /* Build configuration list for PBXNativeTarget "LoopHQ" */;
+			buildPhases = (
+				6D00040200000000DEADBEEF /* Sources */,
+				6D00040300000000DEADBEEF /* Frameworks */,
+				6D00040400000000DEADBEEF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				6D00040500000000DEADBEEF /* LoopHQ */,
+			);
+			name = LoopHQ;
+			packageProductDependencies = (
+				DA17C17000000000000000A4 /* GLTFKit2 */,
+				DA17C18000000000000000A4 /* DracoSwift */,
+			);
+			productName = LoopHQ;
+			productReference = 6D00040100000000DEADBEEF /* LoopHQ.app */;
+			productType = "com.apple.product-type.application";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -387,6 +440,9 @@
 					6C00020A00000000DEADBEEF = {
 						CreatedOnToolsVersion = 26.1;
 					};
+					6D00040A00000000DEADBEEF = {
+						CreatedOnToolsVersion = 26.1;
+					};
 				};
 			};
 			buildConfigurationList = 6A09037E2CD69D9500E70D46 /* Build configuration list for PBXProject "Loop" */;
@@ -403,6 +459,8 @@
 				DA17C13000000000000000A1 /* XCRemoteSwiftPackageReference "swift-nio-ssh" */,
 				DA17C14000000000000000C1 /* XCRemoteSwiftPackageReference "SwiftTerm" */,
 				DA17C15000000000000000E1 /* XCRemoteSwiftPackageReference "Sparkle" */,
+				DA17C17000000000000000A1 /* XCRemoteSwiftPackageReference "GLTFKit2" */,
+				DA17C18000000000000000A1 /* XCRemoteSwiftPackageReference "DracoSwift" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 6A0903842CD69D9500E70D46 /* Products */;
@@ -413,6 +471,7 @@
 				6B00010A00000000DEADBEEF /* LoopMac */,
 				5EE7AAD12FB7A82B00062171 /* LoopShare */,
 				6C00020A00000000DEADBEEF /* LoopVision */,
+				6D00040A00000000DEADBEEF /* LoopHQ */,
 			);
 		};
 /* End PBXProject section */
@@ -446,6 +505,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		6D00040400000000DEADBEEF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -471,6 +537,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		6C00020200000000DEADBEEF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6D00040200000000DEADBEEF /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -921,6 +994,60 @@
 			};
 			name = Release;
 		};
+		6D00040900000000DEADBEEF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = LoopHQ/LoopHQ.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = LoopHQ/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "Loop HQ";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bhat.intel.hq;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = xros;
+				SUPPORTED_PLATFORMS = "xros xrsimulator";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 7;
+				XROS_DEPLOYMENT_TARGET = 26.0;
+			};
+			name = Debug;
+		};
+		6D00040B00000000DEADBEEF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = LoopHQ/LoopHQ.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = LoopHQ/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "Loop HQ";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bhat.intel.hq;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = xros;
+				SUPPORTED_PLATFORMS = "xros xrsimulator";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 7;
+				XROS_DEPLOYMENT_TARGET = 26.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -969,6 +1096,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		6D00040800000000DEADBEEF /* Build configuration list for PBXNativeTarget "LoopHQ" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6D00040900000000DEADBEEF /* Debug */,
+				6D00040B00000000DEADBEEF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
@@ -1002,6 +1138,22 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 2.6.0;
+			};
+		};
+		DA17C17000000000000000A1 /* XCRemoteSwiftPackageReference "GLTFKit2" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/warrenm/GLTFKit2";
+			requirement = {
+				kind = exactVersion;
+				version = 0.5.15;
+			};
+		};
+		DA17C18000000000000000A1 /* XCRemoteSwiftPackageReference "DracoSwift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/warrenm/DracoSwift";
+			requirement = {
+				kind = exactVersion;
+				version = 1.5.7;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -1046,6 +1198,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = DA17C15000000000000000E1 /* XCRemoteSwiftPackageReference "Sparkle" */;
 			productName = Sparkle;
+		};
+		DA17C17000000000000000A4 /* GLTFKit2 */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = DA17C17000000000000000A1 /* XCRemoteSwiftPackageReference "GLTFKit2" */;
+			productName = GLTFKit2;
+		};
+		DA17C18000000000000000A4 /* DracoSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = DA17C18000000000000000A1 /* XCRemoteSwiftPackageReference "DracoSwift" */;
+			productName = DracoSwift;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Loop.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Loop.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,24 @@
 {
-  "originHash" : "4e2114e4dc2fe281cdfb92b9988c47726084643d6084712c3f60ca812fc12d4b",
+  "originHash" : "4dd0c1ba9f889c0d28247e49540cbddc549aed9f7edf65756c24ae0c40544ca4",
   "pins" : [
+    {
+      "identity" : "dracoswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/warrenm/DracoSwift",
+      "state" : {
+        "revision" : "3f85e64b4e62b070871dfdc1e26c058aaa1de63e",
+        "version" : "1.5.7"
+      }
+    },
+    {
+      "identity" : "gltfkit2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/warrenm/GLTFKit2",
+      "state" : {
+        "revision" : "e69e354c4f31ea07b7816b8cbe2ddb28e897d073",
+        "version" : "0.5.15"
+      }
+    },
     {
       "identity" : "libgit2",
       "kind" : "remoteSourceControl",

--- a/Loop.xcodeproj/xcshareddata/xcschemes/Loop_HQ.xcscheme
+++ b/Loop.xcodeproj/xcshareddata/xcschemes/Loop_HQ.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2610"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6D00040A00000000DEADBEEF"
+               BuildableName = "LoopHQ.app"
+               BlueprintName = "LoopHQ"
+               ReferencedContainer = "container:Loop.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6D00040A00000000DEADBEEF"
+            BuildableName = "LoopHQ.app"
+            BlueprintName = "LoopHQ"
+            ReferencedContainer = "container:Loop.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6D00040A00000000DEADBEEF"
+            BuildableName = "LoopHQ.app"
+            BlueprintName = "LoopHQ"
+            ReferencedContainer = "container:Loop.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/LoopHQ/HQAppModel.swift
+++ b/LoopHQ/HQAppModel.swift
@@ -20,6 +20,7 @@ final class HQAppModel {
 
     private let avatarsRoot = Entity()
     private var avatarEntities: [UUID: HQAvatarEntity] = [:]
+    private var worldBuildTask: Task<Void, Never>?
 
     /// Demo stand-in for a second participant (simulator has no SharePlay).
     private(set) var testAvatarEnabled = false
@@ -38,7 +39,17 @@ final class HQAppModel {
         isImmersed = true
         player.resetToSpawn()
         await controls.start()
-        await world.build(googleTilesKey: googleTilesKey)
+        // Build in an app-owned task, never the immersive view's `.task`:
+        // SwiftUI cancels that task whenever the view is torn down (including
+        // transient teardowns while the space opens), and the cancellation
+        // propagates into URLSession, killing in-flight tile downloads with
+        // NSURLError -999. The world outlives the view, so its build must too.
+        if worldBuildTask == nil {
+            let key = googleTilesKey
+            worldBuildTask = Task { [world] in
+                await world.build(googleTilesKey: key)
+            }
+        }
     }
 
     func leftPark() {

--- a/LoopHQ/HQAppModel.swift
+++ b/LoopHQ/HQAppModel.swift
@@ -1,0 +1,125 @@
+import Foundation
+import RealityKit
+import simd
+
+/// Session-wide state for Loop HQ: the world, the player, the input
+/// providers, and multiplayer presence, plus the per-frame loop that stitches
+/// them together.
+@MainActor
+@Observable
+final class HQAppModel {
+
+    static let immersiveSpaceID = "hq.park"
+
+    let world = HQWorld()
+    let player = HQPlayer()
+    let controls = HQControls()
+    let multiplayer = HQMultiplayer()
+
+    private(set) var isImmersed = false
+
+    private let avatarsRoot = Entity()
+    private var avatarEntities: [UUID: HQAvatarEntity] = [:]
+
+    /// Demo stand-in for a second participant (simulator has no SharePlay).
+    private(set) var testAvatarEnabled = false
+    private var testAvatarPhase: Float = 0
+    private let testAvatarID = UUID()
+
+    init() {
+        avatarsRoot.name = "hq.avatars"
+        world.root.addChild(avatarsRoot)
+        multiplayer.configure()
+    }
+
+    // MARK: Lifecycle
+
+    func enteredPark() async {
+        isImmersed = true
+        player.resetToSpawn()
+        await controls.start()
+        await world.build(googleTilesKey: googleTilesKey)
+    }
+
+    func leftPark() {
+        isImmersed = false
+        controls.stop()
+    }
+
+    /// One frame: inputs → locomotion → presence → avatars.
+    func tick(dt: Float) {
+        guard isImmersed, dt > 0 else { return }
+        let dt = min(dt, 1.0 / 30.0) // Don't lurch after a hitch.
+        player.update(
+            dt: dt,
+            intent: controls.intent,
+            headPosition: controls.headPosition(),
+            world: world
+        )
+        multiplayer.broadcastPoseIfDue(position: player.position, yaw: player.yaw)
+        syncAvatars(dt: dt)
+    }
+
+    // MARK: Avatars
+
+    private func syncAvatars(dt: Float) {
+        var players = multiplayer.remotePlayers
+        if testAvatarEnabled {
+            players[testAvatarID] = nextTestAvatarPose(dt: dt)
+        }
+
+        for (id, remote) in players {
+            let entity: HQAvatarEntity
+            if let existing = avatarEntities[id] {
+                entity = existing
+            } else {
+                entity = HQAvatarEntity()
+                entity.position = remote.position
+                avatarEntities[id] = entity
+                avatarsRoot.addChild(entity)
+            }
+            entity.apply(remote, tintSeed: abs(id.hashValue))
+            entity.tick(dt: dt, localPlayerPosition: player.position)
+        }
+        for (id, entity) in avatarEntities where players[id] == nil {
+            entity.removeFromParent()
+            avatarEntities.removeValue(forKey: id)
+        }
+    }
+
+    func toggleTestAvatar() {
+        testAvatarEnabled.toggle()
+    }
+
+    /// Ambles a small loop near spawn so there's someone to walk up to.
+    private func nextTestAvatarPose(dt: Float) -> HQRemotePlayer {
+        testAvatarPhase += dt * 0.35
+        let radius: Float = 4
+        let position = SIMD3(sin(testAvatarPhase) * radius, 0, cos(testAvatarPhase) * radius - 6)
+        let heading = testAvatarPhase + .pi / 2
+        return HQRemotePlayer(
+            id: testAvatarID,
+            name: "Loopy (demo)",
+            position: position,
+            yaw: heading,
+            lastSeen: Date()
+        )
+    }
+
+    // MARK: Configuration
+
+    /// Google Maps Tiles API key: runtime override (set in the lobby) wins,
+    /// then the build-time value injected from Secrets.xcconfig via
+    /// Info.plist. Nil → satellite-imagery fallback world.
+    var googleTilesKey: String? {
+        if let override = UserDefaults.standard.string(forKey: "hq.googleTilesKey"),
+           !override.isEmpty {
+            return override
+        }
+        if let baked = Bundle.main.object(forInfoDictionaryKey: "GoogleTilesAPIKey") as? String,
+           !baked.isEmpty, !baked.hasPrefix("$(") {
+            return baked
+        }
+        return nil
+    }
+}

--- a/LoopHQ/HQAvatarEntity.swift
+++ b/LoopHQ/HQAvatarEntity.swift
@@ -1,0 +1,110 @@
+import RealityKit
+import UIKit
+import simd
+
+/// A simple presence avatar for a remote participant: a tinted capsule-ish
+/// body, a head, and a floating name label that always faces the local
+/// player. Lives in park space under the world root, so walking up to one
+/// works exactly like walking anywhere else.
+@MainActor
+final class HQAvatarEntity: Entity {
+
+    private static let bodyHeight: Float = 1.25
+    private static let headCenter: Float = 1.52
+
+    /// Pivot for the name text, centred above the head so billboarding spins
+    /// the text around its own middle.
+    private var nameLabel: Entity?
+    private var labelledName = ""
+
+    /// Pose smoothing targets (10 Hz network updates → 90 Hz rendering).
+    private var targetPosition = SIMD3<Float>.zero
+    private var targetYaw: Float = 0
+
+    required init() {
+        super.init()
+
+        let tint = UIColor(hue: 0.58, saturation: 0.55, brightness: 0.95, alpha: 1)
+        var bodyMaterial = UnlitMaterial()
+        bodyMaterial.color = .init(tint: tint)
+
+        let body = ModelEntity(
+            mesh: .generateCylinder(height: Self.bodyHeight, radius: 0.17),
+            materials: [bodyMaterial]
+        )
+        body.position = SIMD3(0, 0.25 + Self.bodyHeight / 2, 0)
+        addChild(body)
+
+        var headMaterial = UnlitMaterial()
+        headMaterial.color = .init(tint: UIColor(white: 0.96, alpha: 1))
+        let head = ModelEntity(mesh: .generateSphere(radius: 0.14), materials: [headMaterial])
+        head.position = SIMD3(0, Self.headCenter, 0)
+        addChild(head)
+    }
+
+    func apply(_ player: HQRemotePlayer, tintSeed: Int) {
+        targetPosition = player.position
+        targetYaw = player.yaw
+        if player.name != labelledName {
+            labelledName = player.name
+            rebuildNameLabel(player.name, tintSeed: tintSeed)
+        }
+    }
+
+    /// Per-frame smoothing + billboarding toward the local player.
+    func tick(dt: Float, localPlayerPosition: SIMD3<Float>) {
+        let lerp = min(1, 12 * dt)
+        position += (targetPosition - position) * lerp
+        let yawDelta = atan2(sin(targetYaw - currentYaw), cos(targetYaw - currentYaw))
+        currentYaw += yawDelta * lerp
+        orientation = simd_quatf(angle: -currentYaw, axis: SIMD3(0, 1, 0))
+
+        // Keep the label readable from wherever the local player stands:
+        // rotate the pivot so the text's +z faces the viewer, compensating
+        // for the avatar's own yaw.
+        if let nameLabel {
+            let toViewer = localPlayerPosition - position
+            let flat = SIMD2(toViewer.x, toViewer.z)
+            if simd_length(flat) > 0.01 {
+                let worldYaw = atan2(flat.x, flat.y)
+                nameLabel.orientation = simd_quatf(angle: worldYaw + currentYaw, axis: SIMD3(0, 1, 0))
+            }
+        }
+    }
+
+    private var currentYaw: Float = 0
+
+    private func rebuildNameLabel(_ name: String, tintSeed: Int) {
+        nameLabel?.removeFromParent()
+
+        // Tint the body per participant so groups are tellable-apart.
+        let hue = CGFloat((tintSeed % 12)) / 12.0
+        let tint = UIColor(hue: hue, saturation: 0.55, brightness: 0.92, alpha: 1)
+        for case let model as ModelEntity in children where model.position.y < Self.headCenter - 0.1 {
+            var material = UnlitMaterial()
+            material.color = .init(tint: tint)
+            model.model?.materials = [material]
+        }
+
+        let mesh = MeshResource.generateText(
+            name,
+            extrusionDepth: 0.004,
+            font: .systemFont(ofSize: 0.11, weight: .semibold),
+            containerFrame: .zero,
+            alignment: .center,
+            lineBreakMode: .byTruncatingTail
+        )
+        var material = UnlitMaterial()
+        material.color = .init(tint: .white)
+        let text = ModelEntity(mesh: mesh, materials: [material])
+        // generateText lays out from the baseline origin; offset the model
+        // inside a pivot so the pivot sits at the text's visual centre.
+        let textBounds = text.visualBounds(relativeTo: text)
+        text.position = SIMD3(-textBounds.center.x, -textBounds.center.y, 0)
+        let pivot = Entity()
+        pivot.position = SIMD3(0, Self.headCenter + 0.32, 0)
+        pivot.addChild(text)
+        nameLabel = pivot
+        addChild(pivot)
+    }
+}

--- a/LoopHQ/HQControls.swift
+++ b/LoopHQ/HQControls.swift
@@ -1,0 +1,199 @@
+import ARKit
+import Foundation
+import QuartzCore
+import simd
+
+/// Turns the wearer's hands into a pair of virtual joysticks.
+///
+/// The control scheme (per spec): nothing happens while hands are relaxed.
+/// **Pinching** (thumb tip touching index tip) plants a joystick origin at
+/// the pinch point; **dragging** the pinched hand away from that origin
+/// deflects the stick. Drag distance maps to deflection magnitude, saturating
+/// at `saturationDistance`.
+///
+///  * Left hand  → `move`: drag on the ground plane = walk (forward/back/
+///    strafe), expressed relative to where the wearer's head faces.
+///  * Right hand → `look`: drag right/left = turn, drag up/down = pitch.
+///
+/// Releasing the pinch recentres the stick instantly (you stop).
+///
+/// Also owns the `WorldTrackingProvider`, which supplies the head pose the
+/// locomotion math pivots around. On the simulator (no hand tracking) the
+/// lobby window's on-screen joysticks feed `virtualIntent` instead.
+@MainActor
+@Observable
+final class HQControls {
+
+    /// Pinch begins under this thumb–index distance (m)…
+    private static let pinchStartDistance: Float = 0.022
+    /// …and ends above this one (hysteresis so the stick doesn't flutter).
+    private static let pinchEndDistance: Float = 0.04
+    /// Drag distance (m) for full stick deflection.
+    private static let saturationDistance: Float = 0.14
+    /// Drags shorter than this are ignored (pinch-in-place ≠ walk).
+    private static let deadZone: Float = 0.012
+
+    /// Intent from on-screen joysticks (simulator / accessibility path).
+    var virtualIntent = HQControlIntent()
+
+    /// True once hand-tracking data is flowing (device only).
+    private(set) var handTrackingActive = false
+    private(set) var leftPinching = false
+    private(set) var rightPinching = false
+
+    private let session = ARKitSession()
+    private let worldTracking = WorldTrackingProvider()
+    private let handTracking = HandTrackingProvider()
+
+    private var latestLeft: HandAnchor?
+    private var latestRight: HandAnchor?
+    private var leftStickOrigin: SIMD3<Float>?
+    private var rightStickOrigin: SIMD3<Float>?
+    private var lastHeadPosition = SIMD3<Float>(0, 1.4, 0)
+    private var updatesTask: Task<Void, Never>?
+
+    /// Hand intent + virtual joysticks, clamped.
+    var intent: HQControlIntent {
+        handIntent + virtualIntent
+    }
+
+    func start() async {
+        var providers: [any DataProvider] = []
+        if WorldTrackingProvider.isSupported {
+            providers.append(worldTracking)
+        }
+        if HandTrackingProvider.isSupported {
+            providers.append(handTracking)
+        }
+        guard !providers.isEmpty else { return }
+        do {
+            try await session.run(providers)
+        } catch {
+            print("HQControls: ARKit session failed: \(error)")
+            return
+        }
+        guard HandTrackingProvider.isSupported else { return }
+        updatesTask = Task { [weak self] in
+            guard let handTracking = self?.handTracking else { return }
+            for await update in handTracking.anchorUpdates {
+                guard let self else { return }
+                self.handTrackingActive = true
+                switch update.anchor.chirality {
+                case .left: self.latestLeft = update.event == .removed ? nil : update.anchor
+                case .right: self.latestRight = update.event == .removed ? nil : update.anchor
+                }
+            }
+        }
+    }
+
+    func stop() {
+        updatesTask?.cancel()
+        updatesTask = nil
+        session.stop()
+        handTrackingActive = false
+        leftStickOrigin = nil
+        rightStickOrigin = nil
+    }
+
+    /// Current head position in immersive-space coordinates; the pivot for
+    /// the world-inverse transform. Falls back to a standing-height guess
+    /// until tracking delivers a pose.
+    func headPosition() -> SIMD3<Float> {
+        if let anchor = worldTracking.queryDeviceAnchor(atTimestamp: CACurrentMediaTime()) {
+            let m = anchor.originFromAnchorTransform
+            lastHeadPosition = SIMD3(m.columns.3.x, m.columns.3.y, m.columns.3.z)
+        }
+        return lastHeadPosition
+    }
+
+    // MARK: Hand sticks
+
+    private var handIntent: HQControlIntent {
+        var intent = HQControlIntent()
+        let (headRight, headForward) = headGroundAxes()
+
+        if let drag = stickDrag(for: latestLeft, origin: &leftStickOrigin) {
+            leftPinching = true
+            // Project the drag onto the wearer's ground-plane axes: pushing
+            // the pinched hand away walks forward, sideways strafes.
+            let planar = SIMD3(drag.x, 0, drag.z)
+            intent.move = Self.deflection(SIMD2(
+                simd_dot(planar, headRight),
+                simd_dot(planar, headForward)
+            ))
+        } else {
+            leftPinching = false
+        }
+
+        if let drag = stickDrag(for: latestRight, origin: &rightStickOrigin) {
+            rightPinching = true
+            // Horizontal drag turns, vertical drag pitches.
+            let planar = SIMD3(drag.x, 0, drag.z)
+            intent.look = Self.deflection(SIMD2(
+                simd_dot(planar, headRight),
+                drag.y
+            ))
+        } else {
+            rightPinching = false
+        }
+        return intent
+    }
+
+    /// Drag vector from the planted stick origin, or nil when not pinching.
+    private func stickDrag(for anchor: HandAnchor?, origin: inout SIMD3<Float>?) -> SIMD3<Float>? {
+        guard let anchor, anchor.isTracked,
+              let skeleton = anchor.handSkeleton else {
+            origin = nil
+            return nil
+        }
+        let thumb = skeleton.joint(.thumbTip)
+        let index = skeleton.joint(.indexFingerTip)
+        guard thumb.isTracked, index.isTracked else {
+            origin = nil
+            return nil
+        }
+        let originFromAnchor = anchor.originFromAnchorTransform
+        let thumbPos = (originFromAnchor * thumb.anchorFromJointTransform).columns.3
+        let indexPos = (originFromAnchor * index.anchorFromJointTransform).columns.3
+        let pinchGap = simd_distance(SIMD3(thumbPos.x, thumbPos.y, thumbPos.z),
+                                     SIMD3(indexPos.x, indexPos.y, indexPos.z))
+        let pinchPoint = SIMD3(
+            (thumbPos.x + indexPos.x) / 2,
+            (thumbPos.y + indexPos.y) / 2,
+            (thumbPos.z + indexPos.z) / 2
+        )
+
+        if origin == nil {
+            guard pinchGap < Self.pinchStartDistance else { return nil }
+            origin = pinchPoint
+            return .zero
+        }
+        guard pinchGap < Self.pinchEndDistance, let stickOrigin = origin else {
+            origin = nil
+            return nil
+        }
+        return pinchPoint - stickOrigin
+    }
+
+    /// The wearer's right/forward axes flattened onto the ground plane, so
+    /// drags are interpreted relative to where they're facing.
+    private func headGroundAxes() -> (right: SIMD3<Float>, forward: SIMD3<Float>) {
+        guard let anchor = worldTracking.queryDeviceAnchor(atTimestamp: CACurrentMediaTime()) else {
+            return (SIMD3(1, 0, 0), SIMD3(0, 0, -1))
+        }
+        let m = anchor.originFromAnchorTransform
+        var right = SIMD3(m.columns.0.x, 0, m.columns.0.z)
+        var forward = SIMD3(-m.columns.2.x, 0, -m.columns.2.z)
+        right = simd_length(right) > 0.01 ? simd_normalize(right) : SIMD3(1, 0, 0)
+        forward = simd_length(forward) > 0.01 ? simd_normalize(forward) : SIMD3(0, 0, -1)
+        return (right, forward)
+    }
+
+    /// Dead-zoned, saturating drag → stick deflection in [−1, 1]².
+    private static func deflection(_ drag: SIMD2<Float>) -> SIMD2<Float> {
+        let length = simd_length(drag)
+        guard length > deadZone else { return .zero }
+        let scaled = (length - deadZone) / (saturationDistance - deadZone)
+        return drag / length * min(scaled, 1)
+    }
+}

--- a/LoopHQ/HQDracoDecompressor.h
+++ b/LoopHQ/HQDracoDecompressor.h
@@ -1,0 +1,21 @@
+#import <Foundation/Foundation.h>
+#import <GLTFKit2/GLTFKit2.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Draco mesh decompression plugin for GLTFKit2.
+///
+/// Google's photorealistic 3D tiles are glTF binaries whose meshes are all
+/// KHR_draco_mesh_compression-encoded; GLTFKit2 delegates decompression to a
+/// class registered by name (`GLTFAsset.dracoDecompressorClassName =
+/// "HQDracoDecompressor"`). The implementation links the Draco C++ decoder
+/// from the DracoSwift package. Adapted from GLTFKit2's MIT-licensed
+/// SampleDracoPlugin (github.com/warrenm/GLTFKit2).
+@interface HQDracoDecompressor : NSObject <GLTFDracoMeshDecompressor>
+
++ (GLTFPrimitive *)newPrimitiveForCompressedBufferView:(GLTFBufferView *)bufferView
+                                          attributeMap:(NSDictionary<NSString *, NSNumber *> *)attributes;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/LoopHQ/HQDracoDecompressor.mm
+++ b/LoopHQ/HQDracoDecompressor.mm
@@ -1,0 +1,138 @@
+#import "HQDracoDecompressor.h"
+
+#if __has_include("draco/compression/decode.h")
+
+#include "draco/compression/decode.h"
+
+static GLTFComponentType HQComponentTypeForDracoDataType(draco::DataType type) {
+    switch (type) {
+        case draco::DT_INT8:
+            return GLTFComponentTypeByte;
+        case draco::DT_UINT8:
+            return GLTFComponentTypeUnsignedByte;
+        case draco::DT_INT16:
+            return GLTFComponentTypeShort;
+        case draco::DT_UINT16:
+            return GLTFComponentTypeUnsignedShort;
+        case draco::DT_UINT32:
+            return GLTFComponentTypeUnsignedInt;
+        case draco::DT_FLOAT32:
+            return GLTFComponentTypeFloat;
+        default:
+            return GLTFComponentTypeInvalid;
+    }
+}
+
+static void *HQCopyPointAttributeData(const draco::PointCloud &pc, const draco::PointAttribute &pa, int &outSize) {
+    int pointCount = pc.num_points();
+    draco::DataType type = pa.data_type();
+    int componentCount = pa.num_components();
+    int componentSize = draco::DataTypeLength(type);
+    int elementSize = componentCount * componentSize;
+    int dataSize = pointCount * elementSize;
+    void *data = malloc(dataSize);
+    if (pa.is_mapping_identity()) {
+        auto attrPtr = pa.GetAddress(draco::AttributeValueIndex(0));
+        ::memcpy(data, attrPtr, dataSize);
+    } else {
+        for (draco::PointIndex i(0); i < pointCount; ++i) {
+            const draco::AttributeValueIndex valueIndex = pa.mapped_index(i);
+            void *elementPtr = (char *)data + i.value() * elementSize;
+            pa.GetValue(valueIndex, elementPtr);
+        }
+    }
+    outSize = dataSize;
+    return data;
+}
+
+static uint32_t *HQCopyUInt32IndexDataForMesh(draco::Mesh *mesh, size_t &outIndexCount, size_t &outIndexBufferSize) {
+    size_t indexCount = mesh->num_faces() * 3;
+    size_t indexBufferSize = indexCount * sizeof(uint32_t);
+    uint32_t *indices = (uint32_t *)calloc(indexCount, sizeof(uint32_t));
+    for (int f = 0; f < mesh->num_faces(); ++f) {
+        auto const &face = mesh->face(draco::FaceIndex(f));
+        indices[f * 3 + 0] = face[0].value();
+        indices[f * 3 + 1] = face[1].value();
+        indices[f * 3 + 2] = face[2].value();
+    }
+    outIndexCount = indexCount;
+    outIndexBufferSize = indexBufferSize;
+    return indices;
+}
+
+@implementation HQDracoDecompressor
+
++ (GLTFPrimitive *)newPrimitiveForCompressedBufferView:(GLTFBufferView *)bufferView
+                                          attributeMap:(NSDictionary<NSString *, NSNumber *> *)attributeMap
+{
+    const char *data = (const char *)bufferView.buffer.data.bytes + bufferView.offset;
+    draco::DecoderBuffer buffer;
+    buffer.Init(data, bufferView.length);
+    draco::Decoder decoder;
+    std::unique_ptr<draco::Mesh> mesh;
+    auto typeOrStatus = draco::Decoder::GetEncodedGeometryType(&buffer);
+    if (!typeOrStatus.ok()) {
+        return nil;
+    }
+    GLTFAccessor *indexAccessor = nil;
+    __block NSMutableArray<GLTFAttribute *> *attributes = [NSMutableArray array];
+    draco::EncodedGeometryType geometryType = typeOrStatus.value();
+    if (geometryType == draco::TRIANGULAR_MESH) {
+        auto meshOrStatus = decoder.DecodeMeshFromBuffer(&buffer);
+        if (meshOrStatus.ok()) {
+            mesh = std::move(meshOrStatus).value();
+            draco::Mesh *meshPtr = mesh.get();
+            [attributeMap enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSNumber *index, BOOL *stop) {
+                uint32_t attrId = index.unsignedIntValue;
+                const draco::PointAttribute *dracoAttribute = meshPtr->GetAttributeByUniqueId(attrId);
+                if (dracoAttribute == nullptr) {
+                    return;
+                }
+                int attributeBufferLength;
+                void *attributePtr = HQCopyPointAttributeData(*meshPtr, *dracoAttribute, attributeBufferLength);
+                NSData *attributeData = [NSData dataWithBytesNoCopy:attributePtr
+                                                             length:attributeBufferLength
+                                                       freeWhenDone:YES];
+                GLTFBuffer *attributeBuffer = [[GLTFBuffer alloc] initWithData:attributeData];
+                GLTFBufferView *attributeBufferView = [[GLTFBufferView alloc] initWithBuffer:attributeBuffer
+                                                                                      length:attributeBufferLength
+                                                                                      offset:0
+                                                                                      stride:0];
+                GLTFComponentType componentType = HQComponentTypeForDracoDataType(dracoAttribute->data_type());
+                GLTFValueDimension dimension = static_cast<GLTFValueDimension>(dracoAttribute->num_components());
+                BOOL normalized = dracoAttribute->normalized();
+                GLTFAccessor *attributeAccessor = [[GLTFAccessor alloc] initWithBufferView:attributeBufferView
+                                                                                    offset:0
+                                                                             componentType:componentType
+                                                                                 dimension:dimension
+                                                                                     count:meshPtr->num_points()
+                                                                                normalized:normalized];
+                GLTFAttribute *attribute = [[GLTFAttribute alloc] initWithName:key accessor:attributeAccessor];
+                [attributes addObject:attribute];
+            }];
+            size_t indexCount, indexBufferSize;
+            uint32_t *indices = HQCopyUInt32IndexDataForMesh(meshPtr, indexCount, indexBufferSize);
+            NSData *indexData = [NSData dataWithBytesNoCopy:indices length:indexBufferSize freeWhenDone:YES];
+            GLTFBuffer *indexBuffer = [[GLTFBuffer alloc] initWithData:indexData];
+            GLTFBufferView *indexBufferView = [[GLTFBufferView alloc] initWithBuffer:indexBuffer
+                                                                              length:indexBufferSize
+                                                                              offset:0
+                                                                              stride:0];
+            indexAccessor = [[GLTFAccessor alloc] initWithBufferView:indexBufferView
+                                                              offset:0
+                                                       componentType:GLTFComponentTypeUnsignedInt
+                                                           dimension:GLTFValueDimensionScalar
+                                                               count:indexCount
+                                                          normalized:NO];
+        }
+    }
+    return [[GLTFPrimitive alloc] initWithPrimitiveType:GLTFPrimitiveTypeTriangles
+                                             attributes:attributes
+                                                indices:indexAccessor];
+}
+
+@end
+
+#else
+#error "Draco headers not found — ensure the DracoSwift package is linked to the Loop HQ target."
+#endif

--- a/LoopHQ/HQGeo.swift
+++ b/LoopHQ/HQGeo.swift
@@ -1,0 +1,149 @@
+import simd
+
+/// Geodetic constants and coordinate transforms for Loop HQ.
+///
+/// Loop HQ renders a real place — Salesforce Park in San Francisco — so the
+/// app needs a *park-local* coordinate frame everything (tiles, avatars, the
+/// player) agrees on:
+///
+///   * origin: a fixed anchor point at deck level in the middle of the park
+///   * +x: east, +y: up, −z: north  (right-handed, matches RealityKit)
+///   * units: metres
+///
+/// Google's photorealistic 3D Tiles arrive in earth-centred earth-fixed
+/// (ECEF, z-up) coordinates, so this file owns the double-precision
+/// ECEF ↔ park-frame transform. Everything else in the target works purely
+/// in park-local metres.
+enum HQGeo {
+
+    // MARK: Salesforce Park
+
+    /// Anchor at the centre of the Salesforce Park deck (above the Transit
+    /// Center at 425 Mission St). Approximate to a few metres — the player
+    /// spawns here and the walkable bounds are generous enough to absorb it.
+    static let anchorLatitude = 37.78982
+    static let anchorLongitude = -122.39633
+
+    /// Ellipsoidal (WGS84) height of the park deck in metres. The deck sits
+    /// ~21 m above street level (~3 m orthometric), and the geoid sits ~32 m
+    /// *above* the ellipsoid in SF, so the ellipsoidal height is negative.
+    /// Only used as a first guess for placing streamed tiles — after tiles
+    /// load, the world auto-calibrates by raycasting the actual deck (see
+    /// `HQWorld`).
+    static let anchorEllipsoidalHeight = -8.0
+
+    /// Compass bearing (radians clockwise from true north) of the park's
+    /// long axis. The park runs parallel to Mission St, which follows the
+    /// SoMa grid (~46° east of north). Approximate; bounds are generous.
+    static let parkBearing = 46.0 * .pi / 180.0
+
+    /// Walkable half-extents of the deck along (length, width) of the park's
+    /// long/short axes in metres. The real deck is ~427 m × 52 m; we keep a
+    /// small margin so the player can't step off the edge ("cannot clip").
+    static let walkableHalfExtents = SIMD2<Double>(205, 21)
+
+    /// Radius (m) around the anchor inside which 3D tiles are streamed.
+    /// Covers the park plus the immediately surrounding blocks so towers
+    /// like Salesforce Tower frame the view.
+    static let tileRadius = 320.0
+
+    // MARK: WGS84
+
+    private static let wgs84A = 6_378_137.0
+    private static let wgs84E2 = 6.694_379_990_14e-3
+
+    /// Geodetic (radians) → ECEF metres.
+    static func ecef(latitude: Double, longitude: Double, height: Double) -> SIMD3<Double> {
+        let sinLat = sin(latitude), cosLat = cos(latitude)
+        let n = wgs84A / (1 - wgs84E2 * sinLat * sinLat).squareRoot()
+        return SIMD3(
+            (n + height) * cosLat * cos(longitude),
+            (n + height) * cosLat * sin(longitude),
+            (n * (1 - wgs84E2) + height) * sinLat
+        )
+    }
+
+    /// ECEF position of the park anchor.
+    static let anchorECEF = ecef(
+        latitude: anchorLatitude * .pi / 180,
+        longitude: anchorLongitude * .pi / 180,
+        height: anchorEllipsoidalHeight
+    )
+
+    /// Rotation whose rows are the local east / up / −north axes at the
+    /// anchor, i.e. `park = rotation * (ecef − anchorECEF)`.
+    static let parkFromECEFRotation: simd_double3x3 = {
+        let lat = anchorLatitude * .pi / 180
+        let lon = anchorLongitude * .pi / 180
+        let east = SIMD3(-sin(lon), cos(lon), 0.0)
+        let north = SIMD3(-sin(lat) * cos(lon), -sin(lat) * sin(lon), cos(lat))
+        let up = SIMD3(cos(lat) * cos(lon), cos(lat) * sin(lon), sin(lat))
+        // Rows east/up/-north == transpose of columns east/up/-north.
+        return simd_double3x3(rows: [east, up, -north])
+    }()
+
+    /// Full 4×4 park-from-ECEF transform, including the glTF→ECEF axis fix.
+    ///
+    /// 3D Tiles content is glTF (y-up) embedded in a z-up tileset: the spec
+    /// says renderers must rotate glTF +90° about X so glTF-y becomes
+    /// ECEF-z. Composing that with the ENU rotation above gives one matrix
+    /// to hang streamed tiles under.
+    static let parkFromTileGLTF: simd_double4x4 = {
+        var rot = simd_double4x4(parkFromECEFRotation)            // upper-left 3×3
+        let translate = -(parkFromECEFRotation * anchorECEF)
+        rot.columns.3 = SIMD4(translate, 1)
+        // rotX(+90°): (x, y, z) → (x, −z, y)
+        let gltfToECEF = simd_double4x4(rows: [
+            SIMD4(1, 0, 0, 0),
+            SIMD4(0, 0, -1, 0),
+            SIMD4(0, 1, 0, 0),
+            SIMD4(0, 0, 0, 1),
+        ])
+        return rot * gltfToECEF
+    }()
+
+    /// Geodetic radians → park-local metres (for bounding-region tests).
+    static func parkPosition(latitude: Double, longitude: Double, height: Double) -> SIMD3<Double> {
+        parkFromECEFRotation * (ecef(latitude: latitude, longitude: longitude, height: height) - anchorECEF)
+    }
+
+    /// Clamps a park-space position to the walkable deck rectangle, which is
+    /// rotated by `parkBearing` relative to north.
+    static func clampToWalkableBounds(_ position: SIMD3<Float>) -> SIMD3<Float> {
+        // Park frame: −z is north. Rotate by −bearing about y to express the
+        // position in the deck's long/short axis frame.
+        let bearing = parkBearing
+        let x = Double(position.x), z = Double(position.z)
+        // Long axis unit vector (points along bearing): east*sin(b) − north*… in
+        // park coords: (sin b, 0, −cos b). Short axis: (cos b, 0, sin b).
+        let along = x * sin(bearing) - z * cos(bearing)
+        let across = x * cos(bearing) + z * sin(bearing)
+        let clampedAlong = min(max(along, -walkableHalfExtents.x), walkableHalfExtents.x)
+        let clampedAcross = min(max(across, -walkableHalfExtents.y), walkableHalfExtents.y)
+        return SIMD3(
+            Float(clampedAlong * sin(bearing) + clampedAcross * cos(bearing)),
+            position.y,
+            Float(-clampedAlong * cos(bearing) + clampedAcross * sin(bearing))
+        )
+    }
+}
+
+extension simd_double4x4 {
+    init(_ m: simd_double3x3) {
+        self.init(
+            SIMD4(m.columns.0, 0),
+            SIMD4(m.columns.1, 0),
+            SIMD4(m.columns.2, 0),
+            SIMD4(0, 0, 0, 1)
+        )
+    }
+
+    var asFloat4x4: simd_float4x4 {
+        simd_float4x4(
+            SIMD4<Float>(columns.0),
+            SIMD4<Float>(columns.1),
+            SIMD4<Float>(columns.2),
+            SIMD4<Float>(columns.3)
+        )
+    }
+}

--- a/LoopHQ/HQLobbyView.swift
+++ b/LoopHQ/HQLobbyView.swift
@@ -1,0 +1,201 @@
+import GroupActivities
+import SwiftUI
+
+/// The launcher window: enter the park, start SharePlay, and (mainly for the
+/// simulator, where hand tracking doesn't exist) a pair of on-screen
+/// joysticks that mirror the pinch-drag controls. The window stays visible
+/// inside the immersive space.
+struct HQLobbyView: View {
+    @Environment(HQAppModel.self) private var model
+    @Environment(\.openImmersiveSpace) private var openImmersiveSpace
+    @Environment(\.dismissImmersiveSpace) private var dismissImmersiveSpace
+
+    @State private var tilesKeyDraft =
+        UserDefaults.standard.string(forKey: "hq.googleTilesKey") ?? ""
+
+    var body: some View {
+        @Bindable var multiplayer = model.multiplayer
+
+        VStack(spacing: 20) {
+            VStack(spacing: 4) {
+                Text("Loop HQ")
+                    .font(.extraLargeTitle2)
+                Text("Salesforce Park · San Francisco")
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+            }
+
+            if !model.isImmersed {
+                VStack(spacing: 14) {
+                    TextField("Your name", text: $multiplayer.displayName)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(maxWidth: 280)
+
+                    if model.googleTilesKey == nil {
+                        VStack(spacing: 6) {
+                            Text("No Google Maps Tiles API key — you'll get flat satellite imagery instead of photorealistic 3D.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .multilineTextAlignment(.center)
+                            TextField("Google Maps Tiles API key (optional)", text: $tilesKeyDraft)
+                                .textFieldStyle(.roundedBorder)
+                                .autocorrectionDisabled()
+                                .textInputAutocapitalization(.never)
+                                .frame(maxWidth: 360)
+                                .onSubmit {
+                                    UserDefaults.standard.set(tilesKeyDraft, forKey: "hq.googleTilesKey")
+                                }
+                        }
+                    }
+
+                    Button {
+                        Task { await openImmersiveSpace(id: HQAppModel.immersiveSpaceID) }
+                    } label: {
+                        Label("Enter the Park", systemImage: "figure.walk")
+                            .font(.title3)
+                            .padding(.horizontal, 8)
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+            } else {
+                statusSection
+                controlsSection
+                Button("Leave the Park", role: .destructive) {
+                    Task { await dismissImmersiveSpace() }
+                }
+            }
+
+            multiplayerSection
+        }
+        .padding(28)
+        .frame(minWidth: 480)
+    }
+
+    // MARK: Sections
+
+    private var statusSection: some View {
+        Group {
+            switch model.world.status {
+            case .idle, .building:
+                Label("Building Salesforce Park…", systemImage: "globe.americas")
+            case .ready(let detail):
+                Label(detail, systemImage: "checkmark.circle")
+            case .failed(let message):
+                Label(message, systemImage: "exclamationmark.triangle")
+                    .foregroundStyle(.orange)
+            }
+        }
+        .font(.callout)
+        .foregroundStyle(.secondary)
+    }
+
+    private var controlsSection: some View {
+        VStack(spacing: 10) {
+            if model.controls.handTrackingActive {
+                Text("Pinch + drag: left hand walks, right hand looks")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                Text("Hand tracking unavailable — use the pads below")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            HStack(spacing: 60) {
+                HQJoystickPad(label: "Walk") { vector in
+                    model.controls.virtualIntent.move = vector
+                }
+                HQJoystickPad(label: "Look") { vector in
+                    model.controls.virtualIntent.look = vector
+                }
+            }
+        }
+    }
+
+    private var multiplayerSection: some View {
+        VStack(spacing: 10) {
+            Divider()
+            switch model.multiplayer.state {
+            case .idle:
+                Label("Start a FaceTime call, then share the park", systemImage: "shareplay")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            case .waiting:
+                Label("Joining session…", systemImage: "shareplay")
+            case .joined(let count):
+                Label("\(count) in the park", systemImage: "person.2.fill")
+            }
+
+            HStack(spacing: 16) {
+                Button {
+                    model.multiplayer.startSharing()
+                } label: {
+                    Label("SharePlay", systemImage: "shareplay")
+                }
+
+                Button {
+                    model.toggleTestAvatar()
+                } label: {
+                    Label(
+                        model.testAvatarEnabled ? "Remove demo visitor" : "Add demo visitor",
+                        systemImage: "person.crop.circle.badge.plus"
+                    )
+                }
+                .disabled(!model.isImmersed)
+            }
+
+            if !model.multiplayer.remotePlayers.isEmpty {
+                Text(model.multiplayer.remotePlayers.values.map(\.name).sorted().joined(separator: " · "))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+/// A drag-anywhere joystick pad: deflection is the drag vector from the
+/// gesture's start, saturating at the pad radius. Mirrors the hand-stick
+/// mapping (up = forward / look up).
+struct HQJoystickPad: View {
+    let label: String
+    let onChange: (SIMD2<Float>) -> Void
+
+    @State private var knobOffset = CGSize.zero
+    private let radius: CGFloat = 56
+
+    var body: some View {
+        VStack(spacing: 6) {
+            ZStack {
+                Circle()
+                    .fill(.regularMaterial)
+                    .frame(width: radius * 2, height: radius * 2)
+                Circle()
+                    .fill(.thinMaterial)
+                    .overlay(Circle().strokeBorder(.secondary.opacity(0.4)))
+                    .frame(width: 44, height: 44)
+                    .offset(knobOffset)
+            }
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        var dx = value.translation.width
+                        var dy = value.translation.height
+                        let length = (dx * dx + dy * dy).squareRoot()
+                        if length > radius {
+                            dx *= radius / length
+                            dy *= radius / length
+                        }
+                        knobOffset = CGSize(width: dx, height: dy)
+                        // Screen-up is negative height; sticks treat up as +.
+                        onChange(SIMD2(Float(dx / radius), Float(-dy / radius)))
+                    }
+                    .onEnded { _ in
+                        knobOffset = .zero
+                        onChange(.zero)
+                    }
+            )
+            Text(label)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+    }
+}

--- a/LoopHQ/HQMultiplayer.swift
+++ b/LoopHQ/HQMultiplayer.swift
@@ -1,0 +1,159 @@
+import Combine
+import Foundation
+import GroupActivities
+import simd
+
+/// The SharePlay activity everyone in a Loop HQ session joins.
+struct LoopHQActivity: GroupActivity {
+    static let activityIdentifier = "com.bhat.intel.hq.park"
+
+    var metadata: GroupActivityMetadata {
+        var metadata = GroupActivityMetadata()
+        metadata.title = "Loop HQ — Salesforce Park"
+        metadata.subtitle = "Walk the park together"
+        metadata.type = .generic
+        return metadata
+    }
+}
+
+/// One participant's pose, broadcast a few times a second. Everything is in
+/// the shared park-local frame (`HQGeo`), so a position means the same spot
+/// in the park for every participant regardless of their physical room.
+struct HQPoseMessage: Codable {
+    var name: String
+    var position: SIMD3<Float>
+    var yaw: Float
+}
+
+/// A remote participant as known locally.
+struct HQRemotePlayer: Identifiable {
+    let id: UUID
+    var name: String
+    var position: SIMD3<Float>
+    var yaw: Float
+    var lastSeen: Date
+}
+
+/// SharePlay-backed presence: joins `LoopHQActivity` sessions, broadcasts the
+/// local player's pose, and tracks everyone else's.
+@MainActor
+@Observable
+final class HQMultiplayer {
+
+    enum State: Equatable {
+        case idle
+        case waiting
+        case joined(participants: Int)
+    }
+
+    private(set) var state: State = .idle
+    private(set) var remotePlayers: [UUID: HQRemotePlayer] = [:]
+
+    /// Shown above the local player's avatar on other headsets.
+    var displayName: String =
+        UserDefaults.standard.string(forKey: "hq.displayName") ?? "Visitor" {
+        didSet { UserDefaults.standard.set(displayName, forKey: "hq.displayName") }
+    }
+
+    private var groupSession: GroupSession<LoopHQActivity>?
+    private var messenger: GroupSessionMessenger?
+    private var tasks: Set<Task<Void, Never>> = []
+    private var subscriptions: Set<AnyCancellable> = []
+    private var lastBroadcast = Date.distantPast
+
+    /// Starts listening for sessions (ours or ones we're invited to).
+    func configure() {
+        let task = Task {
+            for await session in LoopHQActivity.sessions() {
+                join(session)
+            }
+        }
+        tasks.insert(task)
+    }
+
+    /// Offers the activity to the active FaceTime/SharePlay context.
+    func startSharing() {
+        Task {
+            do {
+                _ = try await LoopHQActivity().activate()
+            } catch {
+                print("HQMultiplayer: activation failed: \(error)")
+            }
+        }
+    }
+
+    /// Called from the locomotion loop; rate-limits itself.
+    func broadcastPoseIfDue(position: SIMD3<Float>, yaw: Float) {
+        guard let messenger, groupSession?.state == .joined else { return }
+        let now = Date()
+        guard now.timeIntervalSince(lastBroadcast) > 0.1 else { return }
+        lastBroadcast = now
+        let message = HQPoseMessage(name: displayName, position: position, yaw: yaw)
+        Task {
+            try? await messenger.send(message)
+        }
+    }
+
+    func leave() {
+        groupSession?.leave()
+        reset()
+    }
+
+    // MARK: Session plumbing
+
+    private func join(_ session: GroupSession<LoopHQActivity>) {
+        reset()
+        groupSession = session
+        let messenger = GroupSessionMessenger(session: session, deliveryMode: .unreliable)
+        self.messenger = messenger
+        state = .waiting
+
+        session.$state
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] sessionState in
+                if case .invalidated = sessionState {
+                    self?.reset()
+                }
+            }
+            .store(in: &subscriptions)
+
+        session.$activeParticipants
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] participants in
+                guard let self else { return }
+                state = .joined(participants: participants.count)
+                // Drop avatars for participants who left.
+                let activeIDs = Set(participants.map(\.id))
+                remotePlayers = remotePlayers.filter { activeIDs.contains($0.key) }
+            }
+            .store(in: &subscriptions)
+
+        let receiveTask = Task {
+            for await (message, context) in messenger.messages(of: HQPoseMessage.self) {
+                let senderID = context.source.id
+                guard senderID != session.localParticipant.id else { continue }
+                remotePlayers[senderID] = HQRemotePlayer(
+                    id: senderID,
+                    name: message.name,
+                    position: message.position,
+                    yaw: message.yaw,
+                    lastSeen: Date()
+                )
+            }
+        }
+        tasks.insert(receiveTask)
+
+        session.join()
+    }
+
+    private func reset() {
+        for task in tasks { task.cancel() }
+        tasks.removeAll()
+        subscriptions.removeAll()
+        messenger = nil
+        groupSession = nil
+        remotePlayers = [:]
+        state = .idle
+        configure()
+    }
+}

--- a/LoopHQ/HQPlayer.swift
+++ b/LoopHQ/HQPlayer.swift
@@ -1,0 +1,100 @@
+import Foundation
+import RealityKit
+import simd
+
+/// Normalised control inputs for one frame, in player-relative terms.
+/// Components are in [−1, 1].
+struct HQControlIntent {
+    /// x: strafe right, y: walk forward (relative to current heading).
+    var move = SIMD2<Float>.zero
+    /// x: turn right, y: look up. Interpreted as rates.
+    var look = SIMD2<Float>.zero
+
+    static func + (lhs: Self, rhs: Self) -> Self {
+        func clamp(_ v: SIMD2<Float>) -> SIMD2<Float> {
+            simd_clamp(v, SIMD2(repeating: -1), SIMD2(repeating: 1))
+        }
+        return Self(move: clamp(lhs.move + rhs.move), look: clamp(lhs.look + rhs.look))
+    }
+}
+
+/// The player's virtual body in park space, and the world transform that
+/// realises it.
+///
+/// visionOS doesn't let an app move the user's camera — the camera is the
+/// headset. Walking through a world the size of a city block therefore works
+/// by moving the *world* inversely: the player's park-space pose (position +
+/// yaw/pitch) is integrated from the control intents, and `apply` writes the
+/// inverse transform onto the world root so the park slides and rotates
+/// around the wearer, pivoting at their head.
+///
+/// Gravity: the player's y is pinned to the terrain under them every frame
+/// (raycast against streamed photogrammetry, flat deck as fallback), and the
+/// world is positioned so their eyes sit exactly `eyeHeight` above that
+/// surface — no flying, no clipping through the ground. Horizontal motion is
+/// clamped to the park deck so you can't walk off the edge.
+@MainActor
+@Observable
+final class HQPlayer {
+
+    /// Eye height above the terrain: 5'10" in metres, per spec.
+    static let eyeHeight: Float = 1.778
+
+    /// Walking speed at full stick deflection. Brisk but comfortable.
+    static let maxSpeed: Float = 3.0
+
+    /// Turn/look rates at full deflection.
+    static let maxYawRate: Float = 1.7      // rad/s
+    static let maxPitchRate: Float = 1.0    // rad/s
+    static let pitchLimit: Float = 0.55     // rad (~31°)
+
+    /// Park-space position; y is the terrain height under the player.
+    private(set) var position = SIMD3<Float>.zero
+    /// Heading, radians clockwise from north (park −z). 0 looks up the bay.
+    private(set) var yaw: Float = 0
+    /// Virtual look pitch, radians; positive looks up.
+    private(set) var pitch: Float = 0
+
+    /// Integrates one frame of input and re-anchors the world.
+    func update(
+        dt: Float,
+        intent: HQControlIntent,
+        headPosition: SIMD3<Float>,
+        world: HQWorld
+    ) {
+        // Heading-relative movement on the ground plane.
+        let heading = SIMD3<Float>(sin(yaw), 0, -cos(yaw))
+        let right = SIMD3<Float>(cos(yaw), 0, sin(yaw))
+        let drive = right * intent.move.x + heading * intent.move.y
+        position += drive * Self.maxSpeed * dt
+
+        // Look.
+        yaw += intent.look.x * Self.maxYawRate * dt
+        pitch = min(max(pitch + intent.look.y * Self.maxPitchRate * dt, -Self.pitchLimit), Self.pitchLimit)
+
+        // Stay on the deck, pinned to the terrain.
+        position = HQGeo.clampToWalkableBounds(position)
+        position.y = world.smoothedGroundHeight(atParkX: position.x, z: position.z, dt: dt)
+
+        apply(to: world.root, headPosition: headPosition)
+    }
+
+    /// Writes the inverse-player transform onto the world root: the park
+    /// point under the player renders exactly `eyeHeight` below the wearer's
+    /// head, rotated so the player's heading faces render-forward.
+    private func apply(to worldRoot: Entity, headPosition: SIMD3<Float>) {
+        let yawRotation = simd_quatf(angle: yaw, axis: SIMD3(0, 1, 0))
+        let pitchRotation = simd_quatf(angle: -pitch, axis: SIMD3(1, 0, 0))
+        let rotation = pitchRotation * yawRotation
+        let anchor = SIMD3(headPosition.x, headPosition.y - Self.eyeHeight, headPosition.z)
+        worldRoot.orientation = rotation
+        worldRoot.position = anchor - rotation.act(position)
+    }
+
+    /// Spawn in the middle of the deck facing up the park's long axis.
+    func resetToSpawn() {
+        position = .zero
+        yaw = Float(HQGeo.parkBearing)
+        pitch = 0
+    }
+}

--- a/LoopHQ/HQWorld.swift
+++ b/LoopHQ/HQWorld.swift
@@ -191,7 +191,8 @@ final class HQWorld {
             return
         }
 
-        let tiles = pending
+        // Nearest-first: the deck underfoot sharpens before the skyline.
+        let tiles = pending.sorted { $0.distance < $1.distance }
         await withTaskGroup(of: Void.self) { group in
             var iterator = tiles.makeIterator()
             // A few tiles in flight at a time: enough to saturate the

--- a/LoopHQ/HQWorld.swift
+++ b/LoopHQ/HQWorld.swift
@@ -37,6 +37,9 @@ final class HQWorld {
 
     private(set) var status: Status = .idle
     private(set) var tilesLoaded = 0
+    /// Finest geometric error (m) among loaded tiles near the deck — the
+    /// quickest way to tell whether we actually reached Google's max LOD.
+    private(set) var finestGeometricError = Double.infinity
 
     private let parkContent = Entity()
     private let tilesRoot = Entity()
@@ -211,7 +214,9 @@ final class HQWorld {
 
         if tilesLoaded > 0 {
             satellitePlane?.isEnabled = false
-            status = .ready(detail: "Photorealistic Salesforce Park — \(tilesLoaded) tiles")
+            let finest = finestGeometricError.isFinite
+                ? String(format: " (finest LOD ≈ %.2f m)", finestGeometricError) : ""
+            status = .ready(detail: "Photorealistic Salesforce Park — \(tilesLoaded) tiles\(finest)")
         } else {
             status = .failed("No tiles loaded — check the Maps Tiles API key. Showing satellite imagery.")
         }
@@ -227,6 +232,7 @@ final class HQWorld {
             try Task.checkCancellation()
             placeTile(entity, ecefRootTransform: rootTransform)
             tilesLoaded += 1
+            finestGeometricError = min(finestGeometricError, tile.geometricError)
             if case .ready = status {
                 status = .ready(detail: "Streaming photorealistic tiles… \(tilesLoaded)")
             }

--- a/LoopHQ/HQWorld.swift
+++ b/LoopHQ/HQWorld.swift
@@ -1,0 +1,391 @@
+import Foundation
+import RealityKit
+import GLTFKit2
+import MapKit
+import UIKit
+import simd
+
+/// Builds and owns the Salesforce Park environment.
+///
+/// Two layers, both in the park-local frame (`HQGeo`):
+///
+///  1. **Satellite ground** — an MKMapSnapshotter imagery drape on a flat
+///     plane at deck height. Cheap, needs no API key, and doubles as the
+///     floor while tiles stream in.
+///  2. **Photorealistic 3D tiles** — Google's photogrammetry of the real
+///     park and surrounding blocks, streamed via `TileStreamer` and loaded
+///     with GLTFKit2 (+ Draco). Enabled when a Maps Tiles API key is set.
+///
+/// The world also answers "how high is the ground here?" for locomotion by
+/// raycasting streamed geometry, and self-calibrates the deck height after
+/// the first tiles arrive so the player stands exactly on the photogrammetry
+/// surface rather than the a-priori guess in `HQGeo`.
+@MainActor
+@Observable
+final class HQWorld {
+
+    enum Status: Equatable {
+        case idle
+        case building
+        case ready(detail: String)
+        case failed(String)
+    }
+
+    /// Root the player transform is applied to; everything visible lives
+    /// under this entity.
+    let root = Entity()
+
+    private(set) var status: Status = .idle
+    private(set) var tilesLoaded = 0
+
+    private let parkContent = Entity()
+    private let tilesRoot = Entity()
+    private var satellitePlane: ModelEntity?
+    private var deckCalibrated = false
+    private var smoothedGroundY: Float = 0
+
+    init() {
+        root.name = "hq.worldRoot"
+        parkContent.name = "hq.parkContent"
+        tilesRoot.name = "hq.tilesRoot"
+        root.addChild(parkContent)
+        parkContent.addChild(tilesRoot)
+    }
+
+    // MARK: Build
+
+    func build(googleTilesKey: String?) async {
+        guard status == .idle else { return }
+        status = .building
+        await addSkyDome()
+        await addSatelliteGround()
+        if let key = googleTilesKey, !key.isEmpty {
+            await streamTiles(apiKey: key)
+        } else {
+            status = .ready(detail: "Satellite imagery (set a Google Maps Tiles API key for full photorealistic 3D)")
+        }
+    }
+
+    // MARK: Ground height (gravity)
+
+    /// Park-space ground height under (x, z), from a downward raycast against
+    /// streamed tile geometry. Falls back to the flat deck (y = 0) when no
+    /// collision geometry has loaded or the player is over a gap.
+    func groundHeight(atParkX x: Float, z: Float) -> Float {
+        guard let scene = root.scene else { return 0 }
+        let origin = root.convert(position: SIMD3(x, 60, z), to: nil)
+        let down = root.convert(direction: SIMD3(0, -1, 0), to: nil)
+        let hits = scene.raycast(origin: origin, direction: down, length: 200, query: .nearest, relativeTo: nil)
+        guard let hit = hits.first else { return 0 }
+        let parkHit = root.convert(position: hit.position, from: nil)
+        // Reject hits that are clearly a rooftop/underpass artifact rather
+        // than the deck (the deck never deviates more than a few metres).
+        guard parkHit.y > -6, parkHit.y < 10 else { return 0 }
+        return parkHit.y
+    }
+
+    /// Smoothed variant used by the locomotion loop so small mesh steps
+    /// don't judder the camera.
+    func smoothedGroundHeight(atParkX x: Float, z: Float, dt: Float) -> Float {
+        let target = groundHeight(atParkX: x, z: z)
+        let rate: Float = 8
+        smoothedGroundY += (target - smoothedGroundY) * min(1, rate * dt)
+        return smoothedGroundY
+    }
+
+    // MARK: Sky
+
+    private func addSkyDome() async {
+        guard let image = HQWorld.makeSkyGradientImage(),
+              let texture = try? await TextureResource(image: image, options: .init(semantic: .color)) else { return }
+        var material = UnlitMaterial()
+        material.color = .init(texture: .init(texture))
+        let sphere = ModelEntity(mesh: .generateSphere(radius: 900), materials: [material])
+        // Negative x-scale flips the winding so the sphere is visible from
+        // inside.
+        sphere.scale = SIMD3(-1, 1, 1)
+        sphere.position = SIMD3(0, 0, 0)
+        sphere.name = "hq.sky"
+        parkContent.addChild(sphere)
+    }
+
+    private static func makeSkyGradientImage() -> CGImage? {
+        let width = 64, height = 512
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        guard let ctx = CGContext(
+            data: nil, width: width, height: height, bitsPerComponent: 8,
+            bytesPerRow: 0, space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return nil }
+        // Zenith blue → horizon haze → warm ground bounce below the horizon.
+        let colors = [
+            UIColor(red: 0.25, green: 0.48, blue: 0.85, alpha: 1).cgColor,
+            UIColor(red: 0.62, green: 0.78, blue: 0.94, alpha: 1).cgColor,
+            UIColor(red: 0.91, green: 0.90, blue: 0.86, alpha: 1).cgColor,
+            UIColor(red: 0.56, green: 0.55, blue: 0.52, alpha: 1).cgColor,
+        ] as CFArray
+        guard let gradient = CGGradient(colorsSpace: colorSpace, colors: colors, locations: [0, 0.42, 0.52, 1]) else { return nil }
+        ctx.drawLinearGradient(
+            gradient,
+            start: CGPoint(x: 0, y: CGFloat(height)),
+            end: .zero,
+            options: [.drawsBeforeStartLocation, .drawsAfterEndLocation]
+        )
+        return ctx.makeImage()
+    }
+
+    // MARK: Satellite ground
+
+    private func addSatelliteGround() async {
+        // Detail drape over the park itself plus a coarse context drape for
+        // the surrounding blocks, slightly lower to avoid z-fighting.
+        if let detail = await Self.satelliteGroundPlane(spanMeters: 520, textureSize: 2048, y: 0) {
+            satellitePlane = detail
+            parkContent.addChild(detail)
+        }
+        if let context = await Self.satelliteGroundPlane(spanMeters: 2600, textureSize: 2048, y: -0.35) {
+            parkContent.addChild(context)
+        }
+    }
+
+    private static func satelliteGroundPlane(spanMeters: Double, textureSize: CGFloat, y: Float) async -> ModelEntity? {
+        let options = MKMapSnapshotter.Options()
+        options.region = MKCoordinateRegion(
+            center: CLLocationCoordinate2D(latitude: HQGeo.anchorLatitude, longitude: HQGeo.anchorLongitude),
+            latitudinalMeters: spanMeters,
+            longitudinalMeters: spanMeters
+        )
+        options.size = CGSize(width: textureSize, height: textureSize)
+        options.preferredConfiguration = MKImageryMapConfiguration(elevationStyle: .flat)
+        do {
+            let snapshot = try await MKMapSnapshotter(options: options).start()
+            guard let cgImage = snapshot.image.cgImage else { return nil }
+            let texture = try await TextureResource(image: cgImage, options: .init(semantic: .color))
+            var material = UnlitMaterial()
+            material.color = .init(texture: .init(texture))
+            let plane = ModelEntity(
+                mesh: .generatePlane(width: Float(spanMeters), depth: Float(spanMeters)),
+                materials: [material]
+            )
+            plane.position = SIMD3(0, y, 0)
+            plane.name = "hq.satellite.\(Int(spanMeters))"
+            return plane
+        } catch {
+            print("HQWorld: satellite snapshot failed: \(error)")
+            return nil
+        }
+    }
+
+    // MARK: Photorealistic 3D tiles
+
+    private func streamTiles(apiKey: String) async {
+        GLTFAsset.dracoDecompressorClassName = "HQDracoDecompressor"
+        status = .ready(detail: "Streaming photorealistic tiles…")
+
+        let streamer = TileStreamer(apiKey: apiKey)
+        var pending: [TileStreamer.Tile] = []
+        do {
+            _ = try await streamer.collectTiles { pending.append($0) }
+        } catch {
+            status = .failed("Tile discovery failed: \(error.localizedDescription) — falling back to satellite imagery")
+            return
+        }
+
+        let tiles = pending
+        await withTaskGroup(of: Void.self) { group in
+            var iterator = tiles.makeIterator()
+            // A few tiles in flight at a time: enough to saturate the
+            // network without spiking memory during Draco decode.
+            for _ in 0..<4 {
+                if let tile = iterator.next() {
+                    group.addTask { await self.loadTile(tile, streamer: streamer) }
+                }
+            }
+            while await group.next() != nil {
+                if let tile = iterator.next() {
+                    group.addTask { await self.loadTile(tile, streamer: streamer) }
+                }
+            }
+        }
+
+        if tilesLoaded > 0 {
+            satellitePlane?.isEnabled = false
+            status = .ready(detail: "Photorealistic Salesforce Park — \(tilesLoaded) tiles")
+        } else {
+            status = .failed("No tiles loaded — check the Maps Tiles API key. Showing satellite imagery.")
+        }
+    }
+
+    private func loadTile(_ tile: TileStreamer.Tile, streamer: TileStreamer) async {
+        do {
+            let fileURL = try await streamer.download(tile)
+            defer { try? FileManager.default.removeItem(at: fileURL) }
+            let data = try Data(contentsOf: fileURL)
+            let rootTransform = GLBRecenter.rootTransform(ofGLB: data)
+            let entity = try await GLTFRealityKitLoader.load(from: fileURL)
+            try Task.checkCancellation()
+            placeTile(entity, ecefRootTransform: rootTransform)
+            tilesLoaded += 1
+            if case .ready = status {
+                status = .ready(detail: "Streaming photorealistic tiles… \(tilesLoaded)")
+            }
+        } catch {
+            print("HQWorld: tile load failed: \(error)")
+        }
+    }
+
+    /// Parents a loaded tile under the park frame.
+    ///
+    /// ECEF coordinates are ~6.4×10⁶ m, far beyond Float32's useful
+    /// precision, so composing transforms in Float would leave metre-scale
+    /// seams between tiles. `GLBRecenter` recovers the tile's root transform
+    /// from the GLB JSON in double precision; we compose `parkFromTileGLTF ×
+    /// rootTransform` in doubles (the result is park-local and small), zero
+    /// out the corresponding huge node transform inside the loaded entity,
+    /// and apply the composed transform to a wrapper.
+    private func placeTile(_ entity: Entity, ecefRootTransform: simd_double4x4?) {
+        let wrapper = Entity()
+        if let rootTransform = ecefRootTransform,
+           let bigNode = Self.findNodeWithHugeTranslation(in: entity) {
+            bigNode.transform = .identity
+            wrapper.transform = Transform(matrix: (HQGeo.parkFromTileGLTF * rootTransform).asFloat4x4)
+        } else {
+            // Fallback: let Float precision do its best.
+            wrapper.transform = Transform(matrix: HQGeo.parkFromTileGLTF.asFloat4x4)
+        }
+        Self.convertMaterialsToUnlit(entity)
+        wrapper.addChild(entity)
+        tilesRoot.addChild(wrapper)
+        calibrateDeckIfNeeded()
+        Task { await Self.addGroundCollision(to: entity) }
+    }
+
+    private static func findNodeWithHugeTranslation(in entity: Entity) -> Entity? {
+        if simd_length(entity.transform.translation) > 1e5 { return entity }
+        for child in entity.children {
+            if let found = findNodeWithHugeTranslation(in: child) { return found }
+        }
+        return nil
+    }
+
+    /// Photogrammetry textures are pre-baked; physically based shading in a
+    /// lightless immersive space would render them black. Swap every
+    /// material for an unlit one that keeps the base-colour texture.
+    private static func convertMaterialsToUnlit(_ entity: Entity) {
+        if var model = entity.components[ModelComponent.self] {
+            model.materials = model.materials.map { material in
+                guard let pbr = material as? PhysicallyBasedMaterial else { return material }
+                var unlit = UnlitMaterial()
+                if let texture = pbr.baseColor.texture {
+                    unlit.color = .init(tint: .white, texture: texture)
+                } else {
+                    unlit.color = .init(tint: pbr.baseColor.tint)
+                }
+                return unlit
+            }
+            entity.components.set(model)
+        }
+        for child in entity.children {
+            convertMaterialsToUnlit(child)
+        }
+    }
+
+    /// Static-mesh collision so locomotion can raycast the real surface.
+    /// Only worth paying for on tiles near the walkable deck.
+    @MainActor
+    private static func addGroundCollision(to entity: Entity) async {
+        if let model = entity.components[ModelComponent.self] {
+            let bounds = entity.visualBounds(relativeTo: nil)
+            // The world root starts at identity during loading, so
+            // scene-space ≈ park-space here; pad generously.
+            let maxExtent = Float(HQGeo.walkableHalfExtents.x) + 60
+            if abs(bounds.center.x) < maxExtent, abs(bounds.center.z) < maxExtent {
+                do {
+                    let shape = try await ShapeResource.generateStaticMesh(from: model.mesh)
+                    entity.components.set(CollisionComponent(shapes: [shape], isStatic: true))
+                } catch {
+                    print("HQWorld: collision generation failed: \(error)")
+                }
+            }
+        }
+        for child in entity.children {
+            await addGroundCollision(to: child)
+        }
+    }
+
+    /// One-shot vertical alignment: once enough tiles are in, raycast the
+    /// deck under the spawn point and shift the tile layer so the surface
+    /// sits exactly at park y = 0 (where the satellite drape and avatars
+    /// live). Corrects the a-priori ellipsoidal-height guess in `HQGeo`.
+    private func calibrateDeckIfNeeded() {
+        guard !deckCalibrated, tilesLoaded > 8 else { return }
+        let measured = groundHeight(atParkX: 0, z: 0)
+        guard measured != 0 else { return }
+        deckCalibrated = true
+        tilesRoot.position.y -= measured
+    }
+}
+
+/// Extracts a GLB's root-node transform from its JSON chunk in double
+/// precision (see `placeTile` for why Float isn't enough).
+enum GLBRecenter {
+
+    /// Returns the local transform of the asset's first scene root node if
+    /// it carries an earth-scale translation, else nil.
+    static func rootTransform(ofGLB data: Data) -> simd_double4x4? {
+        // GLB: 12-byte header (magic "glTF", version, length), then chunks of
+        // [length, type, payload]; chunk type 0x4E4F534A is JSON.
+        guard data.count > 20 else { return nil }
+        let jsonLength = data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: 12, as: UInt32.self) }
+        let jsonType = data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: 16, as: UInt32.self) }
+        guard jsonType == 0x4E4F_534A, data.count >= 20 + Int(jsonLength) else { return nil }
+        let jsonData = data.subdata(in: 20..<(20 + Int(jsonLength)))
+        guard let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
+              let nodes = json["nodes"] as? [[String: Any]] else { return nil }
+
+        let sceneIndex = json["scene"] as? Int ?? 0
+        let scenes = json["scenes"] as? [[String: Any]]
+        let rootIndices = (scenes?.indices.contains(sceneIndex) == true
+            ? scenes?[sceneIndex]["nodes"] as? [Int]
+            : nil) ?? [0]
+
+        for index in rootIndices where nodes.indices.contains(index) {
+            if let transform = localTransform(of: nodes[index]), isEarthScale(transform) {
+                return transform
+            }
+        }
+        return nil
+    }
+
+    private static func localTransform(of node: [String: Any]) -> simd_double4x4? {
+        if let m = node["matrix"] as? [Double], m.count == 16 {
+            // glTF matrices are column-major.
+            return simd_double4x4(
+                SIMD4(m[0], m[1], m[2], m[3]),
+                SIMD4(m[4], m[5], m[6], m[7]),
+                SIMD4(m[8], m[9], m[10], m[11]),
+                SIMD4(m[12], m[13], m[14], m[15])
+            )
+        }
+        var matrix = matrix_identity_double4x4
+        if let r = node["rotation"] as? [Double], r.count == 4 {
+            let q = simd_quatd(ix: r[0], iy: r[1], iz: r[2], r: r[3])
+            matrix = simd_double4x4(q)
+        }
+        if let s = node["scale"] as? [Double], s.count == 3 {
+            matrix.columns.0 *= s[0]
+            matrix.columns.1 *= s[1]
+            matrix.columns.2 *= s[2]
+        }
+        if let t = node["translation"] as? [Double], t.count == 3 {
+            matrix.columns.3 = SIMD4(t[0], t[1], t[2], 1)
+        } else if node["matrix"] == nil, node["rotation"] == nil, node["scale"] == nil {
+            return nil
+        }
+        return matrix
+    }
+
+    private static func isEarthScale(_ m: simd_double4x4) -> Bool {
+        simd_length(SIMD3(m.columns.3.x, m.columns.3.y, m.columns.3.z)) > 1e5
+    }
+}

--- a/LoopHQ/HQWorld.swift
+++ b/LoopHQ/HQWorld.swift
@@ -216,7 +216,7 @@ final class HQWorld {
         }
     }
 
-    private func loadTile(_ tile: TileStreamer.Tile, streamer: TileStreamer) async {
+    private func loadTile(_ tile: TileStreamer.Tile, streamer: TileStreamer, attempt: Int = 0) async {
         do {
             let fileURL = try await streamer.download(tile)
             defer { try? FileManager.default.removeItem(at: fileURL) }
@@ -230,6 +230,10 @@ final class HQWorld {
                 status = .ready(detail: "Streaming photorealistic tiles… \(tilesLoaded)")
             }
         } catch {
+            // One retry for transient network hiccups; cancellation is final.
+            if attempt == 0, !Task.isCancelled {
+                return await loadTile(tile, streamer: streamer, attempt: 1)
+            }
             print("HQWorld: tile load failed: \(error)")
         }
     }

--- a/LoopHQ/Info.plist
+++ b/LoopHQ/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSHandsTrackingUsageDescription</key>
+	<string>Loop HQ uses your hand positions as joysticks: pinch and drag to walk around the park and look around.</string>
+	<!--
+	  Build-time Google Maps Tiles API key, resolved from Secrets.xcconfig
+	  (GOOGLE_MAPS_TILES_API_KEY). Optional: without it the app falls back
+	  to flat satellite imagery, and a key can also be entered at runtime in
+	  the lobby. The $(VAR) shape survives when unset and is treated as
+	  absent by HQAppModel.
+	-->
+	<key>GoogleTilesAPIKey</key>
+	<string>$(GOOGLE_MAPS_TILES_API_KEY)</string>
+	<!--
+	  Unlike LoopVision (volumetric-only), Loop HQ launches into a regular
+	  window (the lobby) and opens the immersive space from there, so the
+	  default session role stays the plain application role.
+	-->
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationPreferredDefaultSceneSessionRole</key>
+		<string>UIWindowSceneSessionRoleApplication</string>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+		<key>UISceneConfigurations</key>
+		<dict/>
+	</dict>
+</dict>
+</plist>

--- a/LoopHQ/LoopHQ.entitlements
+++ b/LoopHQ/LoopHQ.entitlements
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!--
+	  SharePlay (GroupActivities) for the shared park session. The Apple
+	  Developer App ID for com.bhat.intel.hq needs the Group Activities
+	  capability enabled for device builds; the simulator doesn't check.
+	-->
+	<key>com.apple.developer.group-session</key>
+	<true/>
+</dict>
+</plist>

--- a/LoopHQ/LoopHQApp.swift
+++ b/LoopHQ/LoopHQApp.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+/// Entry point for **Loop HQ** — Loop's multiplayer spatial hangout.
+///
+/// A small lobby window launches a fully immersive, photorealistic
+/// reconstruction of Salesforce Park (San Francisco) rendered from Google's
+/// photogrammetry tiles (satellite imagery fallback). The wearer walks the
+/// park at human scale with pinch-drag hand controls, pinned to the ground
+/// by gravity, and SharePlay participants appear as avatars in the same
+/// park-local coordinate frame.
+@main
+struct LoopHQApp: App {
+    @State private var model = HQAppModel()
+
+    var body: some Scene {
+        WindowGroup {
+            HQLobbyView()
+                .environment(model)
+        }
+        .defaultSize(width: 560, height: 640)
+
+        ImmersiveSpace(id: HQAppModel.immersiveSpaceID) {
+            ParkImmersiveView()
+                .environment(model)
+        }
+        .immersionStyle(selection: .constant(.full), in: .full)
+    }
+}

--- a/LoopHQ/ParkImmersiveView.swift
+++ b/LoopHQ/ParkImmersiveView.swift
@@ -1,0 +1,25 @@
+import RealityKit
+import SwiftUI
+
+/// The immersive scene: hosts the world root and drives the per-frame loop.
+struct ParkImmersiveView: View {
+    @Environment(HQAppModel.self) private var model
+    @State private var updateSubscription: EventSubscription?
+
+    var body: some View {
+        RealityView { content in
+            content.add(model.world.root)
+            updateSubscription = content.subscribe(to: SceneEvents.Update.self) { event in
+                model.tick(dt: Float(event.deltaTime))
+            }
+        }
+        .task {
+            await model.enteredPark()
+        }
+        .onDisappear {
+            updateSubscription?.cancel()
+            updateSubscription = nil
+            model.leftPark()
+        }
+    }
+}

--- a/LoopHQ/TileStreamer.swift
+++ b/LoopHQ/TileStreamer.swift
@@ -1,0 +1,187 @@
+import Foundation
+import simd
+
+/// Minimal client for Google's Photorealistic 3D Tiles (OGC 3D Tiles 1.0).
+///
+/// The API is a tree of tileset JSON documents. Each node carries a bounding
+/// volume, a geometric error (a "how coarse is this" metric in metres), and
+/// either child nodes (finer detail) or content — a Draco-compressed glTF
+/// binary, or a nested tileset JSON to recurse into.
+///
+/// `collectTiles` walks the tree top-down, descending only into nodes whose
+/// bounding volume intersects the park, until the geometric error is small
+/// enough, and returns the GLB URLs to render. Google requires a `key` query
+/// parameter on the root request and a `session` parameter (minted by the
+/// root response, embedded in child URIs) on every request after it.
+struct TileStreamer {
+
+    struct Tile {
+        let url: URL
+        /// Geometric error of the node, kept for debugging/telemetry.
+        let geometricError: Double
+    }
+
+    enum StreamError: Error {
+        case badRootResponse
+        case httpError(Int, URL)
+    }
+
+    let apiKey: String
+
+    /// Stop descending once a node is at least this detailed (metres of
+    /// geometric error). Lower = sharper + many more tiles. ~6 m hits the
+    /// level where façades and trees are clearly readable without blowing
+    /// past Vision Pro memory for a ~300 m radius scene.
+    var targetGeometricError = 6.0
+
+    /// Hard cap on the number of GLBs fetched, as a memory backstop.
+    var maxTiles = 220
+
+    private let baseURL = URL(string: "https://tile.googleapis.com")!
+    private let session: URLSession = {
+        let config = URLSessionConfiguration.default
+        config.httpMaximumConnectionsPerHost = 8
+        return URLSession(configuration: config)
+    }()
+
+    // MARK: Tileset JSON model
+
+    private struct Tileset: Decodable { let root: Node }
+
+    private struct Node: Decodable {
+        struct BoundingVolume: Decodable {
+            /// [west, south, east, north, minHeight, maxHeight], radians + metres.
+            let region: [Double]?
+            /// [cx, cy, cz, xAxis…, yAxis…, zAxis…] oriented box in tileset coords (ECEF).
+            let box: [Double]?
+        }
+        struct Content: Decodable { let uri: String }
+        let boundingVolume: BoundingVolume
+        let geometricError: Double
+        let content: Content?
+        let children: [Node]?
+    }
+
+    // MARK: Traversal
+
+    /// Walks the tileset and streams render-ready tile URLs to `onTile` as
+    /// they are discovered. Returns the total number of tiles selected.
+    func collectTiles(onTile: @escaping (Tile) -> Void) async throws -> Int {
+        var sessionToken: String?
+        let rootData = try await fetch(uri: "/v1/3dtiles/root.json", sessionToken: &sessionToken)
+        let rootTileset = try JSONDecoder().decode(Tileset.self, from: rootData)
+
+        var count = 0
+        var stack: [Node] = [rootTileset.root]
+        while let node = stack.popLast() {
+            if count >= maxTiles { break }
+            guard intersectsPark(node.boundingVolume) else { continue }
+
+            let children = node.children ?? []
+            if node.geometricError > targetGeometricError {
+                if !children.isEmpty {
+                    stack.append(contentsOf: children)
+                    continue
+                }
+                // Leaf-with-content whose content is a nested tileset.
+                if let uri = node.content?.uri, uri.contains(".json") {
+                    var token = sessionToken
+                    let data = try await fetch(uri: uri, sessionToken: &token)
+                    sessionToken = token ?? sessionToken
+                    let nested = try JSONDecoder().decode(Tileset.self, from: data)
+                    stack.append(nested.root)
+                    continue
+                }
+            }
+            // Detailed enough (or nothing finer available): take the GLB.
+            if let uri = node.content?.uri, uri.contains(".glb") {
+                if let url = requestURL(uri: uri, sessionToken: sessionToken) {
+                    count += 1
+                    onTile(Tile(url: url, geometricError: node.geometricError))
+                }
+            } else if !children.isEmpty {
+                // No renderable content at this level; keep descending.
+                stack.append(contentsOf: children)
+            }
+        }
+        return count
+    }
+
+    /// Downloads one tile GLB to a temporary file and returns its URL
+    /// (GLTFKit2 loads from file URLs).
+    func download(_ tile: Tile) async throws -> URL {
+        let (data, response) = try await session.data(from: tile.url)
+        if let http = response as? HTTPURLResponse, http.statusCode != 200 {
+            throw StreamError.httpError(http.statusCode, tile.url)
+        }
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("hq-tiles", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let file = dir.appendingPathComponent(UUID().uuidString + ".glb")
+        try data.write(to: file)
+        return file
+    }
+
+    // MARK: Requests
+
+    private func fetch(uri: String, sessionToken: inout String?) async throws -> Data {
+        guard let url = requestURL(uri: uri, sessionToken: sessionToken) else {
+            throw StreamError.badRootResponse
+        }
+        let (data, response) = try await session.data(from: url)
+        if let http = response as? HTTPURLResponse, http.statusCode != 200 {
+            throw StreamError.httpError(http.statusCode, url)
+        }
+        // Remember the session token Google mints in child URIs so we can
+        // attach it to any URI that arrives without one.
+        if sessionToken == nil,
+           let text = String(data: data, encoding: .utf8),
+           let range = text.range(of: "session=") {
+            let tail = text[range.upperBound...]
+            sessionToken = String(tail.prefix(while: { $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" }))
+        }
+        return data
+    }
+
+    private func requestURL(uri: String, sessionToken: String?) -> URL? {
+        guard var components = URLComponents(url: baseURL.appendingPathComponent(""), resolvingAgainstBaseURL: false),
+              let uriComponents = URLComponents(string: uri) else { return nil }
+        components.path = uriComponents.path
+        var items = uriComponents.queryItems ?? []
+        if let token = sessionToken, !items.contains(where: { $0.name == "session" }) {
+            items.append(URLQueryItem(name: "session", value: token))
+        }
+        items.append(URLQueryItem(name: "key", value: apiKey))
+        components.queryItems = items
+        return components.url
+    }
+
+    // MARK: Bounding-volume tests
+
+    private func intersectsPark(_ volume: Node.BoundingVolume) -> Bool {
+        if let region = volume.region, region.count >= 6 {
+            // Region corners → park frame; test horizontal distance to anchor.
+            let lats = [region[1], region[3]], lons = [region[0], region[2]]
+            var minX = Double.infinity, maxX = -Double.infinity
+            var minZ = Double.infinity, maxZ = -Double.infinity
+            for lat in lats {
+                for lon in lons {
+                    let p = HQGeo.parkPosition(latitude: lat, longitude: lon, height: 0)
+                    minX = min(minX, p.x); maxX = max(maxX, p.x)
+                    minZ = min(minZ, p.z); maxZ = max(maxZ, p.z)
+                }
+            }
+            let r = HQGeo.tileRadius
+            return maxX >= -r && minX <= r && maxZ >= -r && minZ <= r
+        }
+        if let box = volume.box, box.count >= 12 {
+            // Conservative sphere test in ECEF: centre distance vs box radius
+            // + park radius.
+            let center = SIMD3(box[0], box[1], box[2])
+            let radius = simd_length(SIMD3(box[3], box[4], box[5]))
+                + simd_length(SIMD3(box[6], box[7], box[8]))
+                + simd_length(SIMD3(box[9], box[10], box[11]))
+            return simd_distance(center, HQGeo.anchorECEF) <= radius + HQGeo.tileRadius
+        }
+        return true // Unknown volume type: be permissive.
+    }
+}

--- a/LoopHQ/TileStreamer.swift
+++ b/LoopHQ/TileStreamer.swift
@@ -38,11 +38,12 @@ struct TileStreamer {
 
     /// Distance-based level of detail: the geometric error (m) we'll accept
     /// for a node whose bounding volume is `distance` metres from the park
-    /// anchor. Full photogrammetry resolution on and around the deck (the
-    /// finest Google tiles are ~1 m GE), coarsening smoothly with distance so
-    /// the skyline stays cheap. The divisor is the quality/memory knob.
+    /// anchor. Within ~75 m the target sits below Google's finest published
+    /// level (leaves bottom out around 0.25–0.5 m GE), forcing descent to the
+    /// true leaves; beyond that it grows linearly so the skyline stays cheap.
+    /// The 70/30 constants are the quality/memory knobs.
     static func targetGeometricError(atDistance distance: Double) -> Double {
-        min(max(distance / 35.0, 1.0), 20.0)
+        min(max(0.2, (distance - 70.0) / 30.0), 20.0)
     }
 
     private let baseURL = URL(string: "https://tile.googleapis.com")!
@@ -80,16 +81,27 @@ struct TileStreamer {
         let rootTileset = try JSONDecoder().decode(Tileset.self, from: rootData)
 
         var count = 0
-        var stack: [Node] = [rootTileset.root]
-        while let node = stack.popLast() {
+        // Nearest-first traversal (linear-scan priority queue; the frontier
+        // stays small): when the tile budget runs out, what gets dropped is
+        // distant skyline, never the deck underfoot.
+        var frontier: [(node: Node, distance: Double)] = [
+            (rootTileset.root, horizontalDistance(of: rootTileset.root.boundingVolume))
+        ]
+        while !frontier.isEmpty {
             if count >= maxTiles { break }
+            var nearest = 0
+            for index in frontier.indices where frontier[index].distance < frontier[nearest].distance {
+                nearest = index
+            }
+            let (node, distance) = frontier.remove(at: nearest)
             guard intersectsPark(node.boundingVolume) else { continue }
 
             let children = node.children ?? []
-            let distance = horizontalDistance(of: node.boundingVolume)
             if node.geometricError > Self.targetGeometricError(atDistance: distance) {
                 if !children.isEmpty {
-                    stack.append(contentsOf: children)
+                    frontier.append(contentsOf: children.map {
+                        ($0, horizontalDistance(of: $0.boundingVolume))
+                    })
                     continue
                 }
                 // Leaf-with-content whose content is a nested tileset.
@@ -98,7 +110,7 @@ struct TileStreamer {
                     let data = try await fetch(uri: uri, sessionToken: &token)
                     sessionToken = token ?? sessionToken
                     let nested = try JSONDecoder().decode(Tileset.self, from: data)
-                    stack.append(nested.root)
+                    frontier.append((nested.root, horizontalDistance(of: nested.root.boundingVolume)))
                     continue
                 }
             }
@@ -110,7 +122,9 @@ struct TileStreamer {
                 }
             } else if !children.isEmpty {
                 // No renderable content at this level; keep descending.
-                stack.append(contentsOf: children)
+                frontier.append(contentsOf: children.map {
+                    ($0, horizontalDistance(of: $0.boundingVolume))
+                })
             }
         }
         return count

--- a/LoopHQ/TileStreamer.swift
+++ b/LoopHQ/TileStreamer.swift
@@ -19,6 +19,9 @@ struct TileStreamer {
         let url: URL
         /// Geometric error of the node, kept for debugging/telemetry.
         let geometricError: Double
+        /// Horizontal distance (m) from the park anchor; used to load
+        /// nearest tiles first.
+        let distance: Double
     }
 
     enum StreamError: Error {
@@ -28,14 +31,19 @@ struct TileStreamer {
 
     let apiKey: String
 
-    /// Stop descending once a node is at least this detailed (metres of
-    /// geometric error). Lower = sharper + many more tiles. ~6 m hits the
-    /// level where façades and trees are clearly readable without blowing
-    /// past Vision Pro memory for a ~300 m radius scene.
-    var targetGeometricError = 6.0
+    /// Hard cap on the number of GLBs fetched, as a memory backstop. Tiles
+    /// are loaded nearest-first, so when the cap bites it's distant context
+    /// that gets dropped, never the deck underfoot.
+    var maxTiles = 450
 
-    /// Hard cap on the number of GLBs fetched, as a memory backstop.
-    var maxTiles = 220
+    /// Distance-based level of detail: the geometric error (m) we'll accept
+    /// for a node whose bounding volume is `distance` metres from the park
+    /// anchor. Full photogrammetry resolution on and around the deck (the
+    /// finest Google tiles are ~1 m GE), coarsening smoothly with distance so
+    /// the skyline stays cheap. The divisor is the quality/memory knob.
+    static func targetGeometricError(atDistance distance: Double) -> Double {
+        min(max(distance / 35.0, 1.0), 20.0)
+    }
 
     private let baseURL = URL(string: "https://tile.googleapis.com")!
     private let session: URLSession = {
@@ -78,7 +86,8 @@ struct TileStreamer {
             guard intersectsPark(node.boundingVolume) else { continue }
 
             let children = node.children ?? []
-            if node.geometricError > targetGeometricError {
+            let distance = horizontalDistance(of: node.boundingVolume)
+            if node.geometricError > Self.targetGeometricError(atDistance: distance) {
                 if !children.isEmpty {
                     stack.append(contentsOf: children)
                     continue
@@ -97,7 +106,7 @@ struct TileStreamer {
             if let uri = node.content?.uri, uri.contains(".glb") {
                 if let url = requestURL(uri: uri, sessionToken: sessionToken) {
                     count += 1
-                    onTile(Tile(url: url, geometricError: node.geometricError))
+                    onTile(Tile(url: url, geometricError: node.geometricError, distance: distance))
                 }
             } else if !children.isEmpty {
                 // No renderable content at this level; keep descending.
@@ -156,6 +165,30 @@ struct TileStreamer {
     }
 
     // MARK: Bounding-volume tests
+
+    /// Conservative horizontal distance (m) from the park anchor to the
+    /// node's bounding volume (0 when the volume covers the anchor). Drives
+    /// the distance-based LOD, so erring small just means extra detail.
+    private func horizontalDistance(of volume: Node.BoundingVolume) -> Double {
+        if let region = volume.region, region.count >= 6 {
+            let center = HQGeo.parkPosition(
+                latitude: (region[1] + region[3]) / 2,
+                longitude: (region[0] + region[2]) / 2,
+                height: 0
+            )
+            let corner = HQGeo.parkPosition(latitude: region[3], longitude: region[2], height: 0)
+            let halfDiagonal = simd_length(SIMD2(corner.x - center.x, corner.z - center.z))
+            return max(0, simd_length(SIMD2(center.x, center.z)) - halfDiagonal)
+        }
+        if let box = volume.box, box.count >= 12 {
+            let center = SIMD3(box[0], box[1], box[2])
+            let radius = simd_length(SIMD3(box[3], box[4], box[5]))
+                + simd_length(SIMD3(box[6], box[7], box[8]))
+                + simd_length(SIMD3(box[9], box[10], box[11]))
+            return max(0, simd_distance(center, HQGeo.anchorECEF) - radius)
+        }
+        return 0
+    }
 
     private func intersectsPark(_ volume: Node.BoundingVolume) -> Bool {
         if let region = volume.region, region.count >= 6 {

--- a/Secrets.xcconfig.example
+++ b/Secrets.xcconfig.example
@@ -35,3 +35,8 @@ FIREWORKS_API_KEY =
 CURSOR_API_KEY =
 OBSIDIAN_API_KEY =
 OBSIDIAN_BASE_URL =
+// Loop HQ (visionOS) — Google Map Tiles API key with "Photorealistic 3D
+// Tiles" enabled (console.cloud.google.com → Map Tiles API). Optional:
+// without it Loop HQ renders flat satellite imagery instead of full
+// photorealistic 3D, and a key can also be entered in the app's lobby.
+GOOGLE_MAPS_TILES_API_KEY =


### PR DESCRIPTION
## Loop HQ — visionOS

New standalone visionOS target, **Loop HQ**, selectable from the scheme list as `Loop_HQ`. It drops the wearer into a photorealistic, walkable Salesforce Park (SF) at human scale, with hand-as-joystick locomotion and SharePlay multiplayer.

### Key result mapping

- **(A) Switch scheme & run on Vision Pro** — `Loop_HQ` shared scheme; builds for `xros` and `xrsimulator` (both verified). Bundle id `com.bhat.intel.hq`, same team/signing pattern as LoopVision.
- **(B) Photoreal Salesforce Park, 5'10", grounded** — Google Photorealistic 3D Tiles streamed around the park (`TileStreamer` + GLTFKit2 + Draco), or a satellite-imagery drape when no key is configured. Eye height is pinned at 1.778 m above the terrain (`HQPlayer`), with downward raycasts against the streamed photogrammetry for gravity, one-shot deck auto-calibration, and bounds clamped to the deck so you can't fly, fall off, or clip.
- **(C) Pinch-drag controls** — `HQControls` (ARKit hand tracking): **left** pinch+drag = 2D ground-plane movement vector, drag distance = speed; **right** pinch+drag = yaw/pitch. Releasing the pinch stops instantly. The lobby window has equivalent on-screen joystick pads (that's also the simulator path, where hand tracking doesn't exist).
- **(D) Other people as avatars** — SharePlay (`LoopHQActivity` + `GroupSessionMessenger`) broadcasts poses ~10 Hz in the shared park-local frame; remote participants render as tinted capsule avatars with billboarded name labels you can walk up to. An **"Add demo visitor"** button spawns a local stand-in for single-headset testing.

### Setup

- **Photoreal tiles**: set `GOOGLE_MAPS_TILES_API_KEY` in `Secrets.xcconfig` (Map Tiles API with Photorealistic 3D Tiles enabled), or paste a key in the lobby at runtime. Without one you get the flat satellite fallback (functional, just not 3D).
- **SharePlay on device**: the `com.bhat.intel.hq` App ID needs the Group Activities capability; join via FaceTime.

### Implementation notes

- **Float precision**: ECEF coordinates (~6.4×10⁶ m) exceed Float32 precision, which would leave metre-scale seams between tiles. `GLBRecenter` re-parses each GLB's root transform from its JSON chunk in double precision and composes the park-local transform in doubles before touching RealityKit.
- **Draco**: Google's tiles are entirely Draco-compressed; `HQDracoDecompressor` (ObjC++, adapted from GLTFKit2's MIT sample plugin) plugs the DracoSwift decoder into GLTFKit2.
- **Lighting**: photogrammetry textures are pre-baked, so materials are converted to unlit on load (PBR in a lightless full immersive space renders black).
- New deps (Loop HQ target only): `GLTFKit2` 0.5.15, `DracoSwift` 1.5.7 — both ship xros/xrsimulator slices.
- Approximations to tune on hardware: park bearing/centre constants in `HQGeo`, tile geometric-error cutoff (detail vs. memory) in `TileStreamer`.

### Testing

- `xcodebuild -scheme Loop_HQ` for visionOS Simulator and device (`CODE_SIGNING_ALLOWED=NO`): **both succeed**.
- Smoke-tested on the Vision Pro simulator: launches into the park, sky + satellite world render, lobby pads/SharePlay/demo-visitor UI all present, no crashes in logs. On-device hand tracking + SharePlay still need a live Vision Pro to validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)