### PR TITLE
site: route download CTAs to latest Mac release + TestFlight

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -45,7 +45,7 @@
     </div>
     <div class="nav__ctas">
       <a class="nav__github" href="https://github.com/getathelas/LoopHarness" target="_blank" rel="noreferrer">github&nbsp;↗</a>
-      <a class="nav__testflight" href="https://github.com/getathelas/LoopHarness#setup" target="_blank" rel="noreferrer">Get the app</a>
+      <a class="nav__testflight" href="https://testflight.apple.com/join/sptcA35U" target="_blank" rel="noreferrer">Get the app</a>
     </div>
   </nav>
 
@@ -70,11 +70,11 @@
     </p>
 
     <div class="hero__ctas" id="download">
-      <a class="btn btn--primary" href="https://github.com/getathelas/LoopHarness#setup">
-        Build for Mac
+      <a class="btn btn--primary" href="https://github.com/getathelas/LoopHarness/releases/latest" target="_blank" rel="noreferrer">
+        Download for Mac
       </a>
-      <a class="btn btn--ghost" href="https://github.com/getathelas/LoopHarness#setup">
-        Build for iPhone
+      <a class="btn btn--ghost" href="https://testflight.apple.com/join/sptcA35U" target="_blank" rel="noreferrer">
+        Get on iPhone
       </a>
     </div>
   </div>


### PR DESCRIPTION
Wires up the loopharness.com download CTAs so the site routes to a real Mac download and the iOS TestFlight build, instead of pointing everything at the build-from-source `#setup` anchor.

## Changes (`website/index.html`)
- **Hero primary CTA** — "Build for Mac" → **"Download for Mac"**, now linking to [`/releases/latest`](https://github.com/getathelas/LoopHarness/releases/latest). This auto-tracks the newest release (currently the signed + notarized `v1.0-jun20` DMG) so the link never needs updating for future builds.
- **Hero secondary CTA** — "Build for iPhone" → **"Get on iPhone"**, now linking to the TestFlight join URL `https://testflight.apple.com/join/sptcA35U`.
- **Nav "Get the app"** — now points at the same TestFlight URL (was `#setup`).

## Notes
- I used the `/releases/latest` *page* rather than a direct DMG asset URL on purpose: manual builds ship `Loop.dmg` while the CI workflow ships `Loop-<run>.dmg`, so a fixed asset filename wouldn't be stable across release types. The release page always surfaces the right asset.
- To make `/releases/latest` resolve, `v1.0-jun20` was flagged as the latest release (it previously was not).
- Building from source is still documented and linked from the Open Source section, so that path isn't lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)