### PR TITLE
site: route Mac download CTA to latest release

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -70,8 +70,8 @@
     </p>
 
     <div class="hero__ctas" id="download">
-      <a class="btn btn--primary" href="https://github.com/getathelas/LoopHarness#setup">
-        Build for Mac
+      <a class="btn btn--primary" href="https://github.com/getathelas/LoopHarness/releases/latest" target="_blank" rel="noreferrer">
+        Download for Mac
       </a>
       <a class="btn btn--ghost" href="https://testflight.apple.com/join/sptcA35U" target="_blank" rel="noreferrer">
         Build for iPhone


### PR DESCRIPTION
Points the loopharness.com "Download for Mac" CTA at a real download instead of the build-from-source `#setup` anchor.

## Change (`website/index.html`)
- **Hero primary CTA** — "Build for Mac" → **"Download for Mac"**, now linking to [`/releases/latest`](https://github.com/getathelas/LoopHarness/releases/latest) (currently the signed + notarized `v1.0-jun20` DMG). The link auto-tracks future releases.

TestFlight routing (nav "Get the app" + the iPhone CTA) is already in place on `develop`, so this is just the Mac side.

## Notes
- Linked to the `/releases/latest` *page* rather than a fixed asset URL: manual builds ship `Loop.dmg` while CI ships `Loop-<run>.dmg`, so a hardcoded filename wouldn't be stable. The page always surfaces the correct asset.
- `v1.0-jun20` is flagged as the latest release so `/releases/latest` resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)