### PR TITLE
Improve startup responsiveness, Mac shortcut, and runtime docs

### DIFF
--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -791,7 +791,7 @@
 				INFOPLIST_FILE = LoopMac/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Loop;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
-				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Loop records your voice when you hold control + fn so it can transcribe and send it to the assistant.";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Loop records your voice when you hold shift + control so it can transcribe and send it to the assistant.";
 				INFOPLIST_KEY_NSPrincipalClass = NSApplication;
 				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Loop transcribes your speech so the assistant can hear what you say.";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -848,7 +848,7 @@
 				INFOPLIST_FILE = LoopMac/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Loop;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
-				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Loop records your voice when you hold control + fn so it can transcribe and send it to the assistant.";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Loop records your voice when you hold shift + control so it can transcribe and send it to the assistant.";
 				INFOPLIST_KEY_NSPrincipalClass = NSApplication;
 				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Loop transcribes your speech so the assistant can hear what you say.";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/LoopIOS/AgentHarness/AgentHarness.swift
+++ b/LoopIOS/AgentHarness/AgentHarness.swift
@@ -99,6 +99,28 @@ final class AgentHarness {
     /// static bundled set; dynamic skills get appended on every refresh.
     private var staticToolSchemasCount: Int = 0
 
+    // MARK: - Persistent-state bootstrap
+    //
+    // Resolving the iCloud workspace and downloading evicted self-docs,
+    // dynamic skills, and MCP records can take minutes on a newly set-up
+    // iPhone. None of that work is required to construct the first usable
+    // chat screen, so iOS performs it on this serial utility queue. Calls to
+    // `chat` that arrive before it finishes are resumed asynchronously rather
+    // than blocking the main thread.
+    private enum PersistenceBootstrapState {
+        case notStarted
+        case loading
+        case ready
+    }
+
+    private let persistenceQueue = DispatchQueue(
+        label: "loop.agentHarness.persistence",
+        qos: .utility
+    )
+    private let persistenceStateLock = NSLock()
+    private var persistenceBootstrapState: PersistenceBootstrapState = .notStarted
+    private var persistenceReadyCallbacks: [() -> Void] = []
+
     /// Human-readable catalog of the bundled skills, surfaced by the side
     /// drawer's "Skills" tab. This intentionally mirrors the `systemPromptFragment`
     /// list assembled in `init()` below (same order) — when you add a skill
@@ -197,40 +219,14 @@ final class AgentHarness {
         self.staticToolsDocLength = toolsDoc.count
         self.staticToolSchemasCount = toolSchemas.count
 
-        // Override the templated defaults with anything the agent has
-        // persisted from prior sessions. Missing files just leave the
-        // defaults in place. Touching Workspace.shared here also bootstraps
-        // the iCloud container resolution + legacy migration.
-        _ = Workspace.shared
-        loadPersistedSelfDocs()
-
-        // Seed any bundled starter skills into the workspace on first launch.
-        // Currently there are none (BundledSkillSeeds.all is empty), so this is
-        // a no-op; kept so a starter can be reintroduced later. Subsequent
-        // launches detect existing files on disk and skip.
-        BundledSkillSeeds.seedIfNeeded()
-
-        // Seed the reference docs (ABOUT_LOOP.md — the agent's own code map)
-        // into the Workspace root on first launch. Idempotent: skipped once
-        // the file exists, so user/agent edits survive.
-        BundledDocSeeds.seedIfNeeded()
-
-        // Initial scan + refresh of dynamic-skill schemas. The registry's
-        // didReload hook keeps us in sync as skills get added/removed
-        // mid-session.
-        DynamicSkillRegistry.shared.didReload = { [weak self] in
-            self?.refreshDynamicSkills()
-        }
-        DynamicSkillRegistry.shared.reload()
-
-        // Same plumbing for remote MCP servers the user has installed. We
-        // share `refreshDynamicSkills` because both registries land in the
-        // same trailing section of `toolSchemas` / `toolsDoc`.
-        MCPRegistry.shared.didReload = { [weak self] in
-            self?.refreshDynamicSkills()
-        }
-
-        refreshDynamicSkills()
+        #if !os(iOS)
+        // The Mac launch path historically expects workspace-backed state to
+        // be ready when this singleton returns. Preserve that behavior there;
+        // iOS starts the same work asynchronously after installing its UI.
+        persistenceBootstrapState = .loading
+        performPersistenceBootstrap()
+        finishPersistenceBootstrap()
+        #endif
 
         // Resume polling any Cursor cloud agents dispatched in a prior
         // session so their PR link still posts back after a relaunch.
@@ -255,6 +251,77 @@ final class AgentHarness {
         #if canImport(HealthKit) && os(iOS)
         _ = HealthKitManager.shared
         #endif
+    }
+
+    /// Begin loading workspace-backed agent state without blocking the caller.
+    /// Safe to call repeatedly; only the first call schedules work.
+    func startPersistenceBootstrap() {
+        persistenceStateLock.lock()
+        guard persistenceBootstrapState == .notStarted else {
+            persistenceStateLock.unlock()
+            return
+        }
+        persistenceBootstrapState = .loading
+        persistenceStateLock.unlock()
+
+        let startedAt = Date()
+        print("AgentHarness: starting workspace bootstrap in background")
+        persistenceQueue.async { [weak self] in
+            guard let self = self else { return }
+            self.performPersistenceBootstrap()
+            let elapsed = Date().timeIntervalSince(startedAt)
+            print("AgentHarness: workspace bootstrap finished in \(String(format: "%.1f", elapsed))s")
+            self.finishPersistenceBootstrap()
+        }
+    }
+
+    private var isPersistenceReady: Bool {
+        persistenceStateLock.lock(); defer { persistenceStateLock.unlock() }
+        return persistenceBootstrapState == .ready
+    }
+
+    private func whenPersistenceReady(_ callback: @escaping () -> Void) {
+        persistenceStateLock.lock()
+        if persistenceBootstrapState == .ready {
+            persistenceStateLock.unlock()
+            DispatchQueue.main.async(execute: callback)
+        } else {
+            persistenceReadyCallbacks.append(callback)
+            persistenceStateLock.unlock()
+        }
+    }
+
+    /// Runs on `persistenceQueue` on iOS. This is the only launch-time path
+    /// allowed to resolve or hydrate the iCloud workspace.
+    private func performPersistenceBootstrap() {
+        _ = Workspace.shared
+        loadPersistedSelfDocs()
+
+        BundledSkillSeeds.seedIfNeeded()
+        BundledDocSeeds.seedIfNeeded()
+
+        DynamicSkillRegistry.shared.didReload = { [weak self] in
+            self?.refreshDynamicSkills()
+        }
+        DynamicSkillRegistry.shared.reload()
+
+        MCPRegistry.shared.didReload = { [weak self] in
+            self?.refreshDynamicSkills()
+        }
+
+        refreshDynamicSkills()
+    }
+
+    private func finishPersistenceBootstrap() {
+        persistenceStateLock.lock()
+        persistenceBootstrapState = .ready
+        let callbacks = persistenceReadyCallbacks
+        persistenceReadyCallbacks.removeAll()
+        persistenceStateLock.unlock()
+
+        for callback in callbacks {
+            DispatchQueue.main.async(execute: callback)
+        }
     }
 
     // MARK: - Dynamic skill integration
@@ -369,6 +436,22 @@ final class AgentHarness {
               tools: [[String: Any]]? = nil,
               onPartial: ((String) -> Void)? = nil,
               completion: @escaping(MessageStruct?, Error?) -> Void) {
+
+        #if os(iOS)
+        // A user can start typing immediately while a new phone is still
+        // hydrating its iCloud workspace. Keep the UI responsive and resume
+        // this request once the documents and registries are ready.
+        startPersistenceBootstrap()
+        guard isPersistenceReady else {
+            whenPersistenceReady { [weak self] in
+                self?.chat(messages: messages,
+                           tools: tools,
+                           onPartial: onPartial,
+                           completion: completion)
+            }
+            return
+        }
+        #endif
 
         // Slash commands short-circuit before any inference call. The latest
         // user message is the trigger; if it starts with a recognized
@@ -596,6 +679,20 @@ final class AgentHarness {
     /// or edit them externally) without having to wait for a tool call to
     /// trigger the first persistence.
     func seedSelfDocsIfMissing() {
+        #if os(iOS)
+        // Onboarding calls this from main. Queue it behind the initial
+        // workspace bootstrap so first launch never waits on iCloud file
+        // coordination before presenting the greeting.
+        startPersistenceBootstrap()
+        persistenceQueue.async { [weak self] in
+            self?.seedSelfDocsIfMissingNow()
+        }
+        #else
+        seedSelfDocsIfMissingNow()
+        #endif
+    }
+
+    private func seedSelfDocsIfMissingNow() {
         let fm = FileManager.default
         for doc in SelfDoc.allCases {
             let url = selfDocURL(for: doc)

--- a/LoopIOS/MainVC.swift
+++ b/LoopIOS/MainVC.swift
@@ -34,6 +34,11 @@ class MainVC: MessagingVC {
     /// rather than reloading on every layout pass.
     private var feedStackLoaded = false
 
+    /// CardStore reads its JSON files from the iCloud workspace. On a new
+    /// phone those files may be evicted placeholders, so its first load must
+    /// never happen from `viewDidLoad` / `viewDidLayoutSubviews` on main.
+    private var feedStackLoading = false
+
     /// The immersive agent view when it is hosted as a child view
     /// controller (instead of a fullscreen modal). Kept alive so dismiss
     /// can tear it down cleanly.
@@ -443,9 +448,20 @@ class MainVC: MessagingVC {
         // chat. Reset the flag when the chat fills so the next new chat deals a
         // fresh deck — and so we never reload mid-swipe on a layout pass.
         if chatEmpty {
-            if !feedStackLoaded {
-                feedCardList?.setCards(CardStore.shared.feedCards)
-                feedStackLoaded = true
+            if !feedStackLoaded && !feedStackLoading {
+                feedStackLoading = true
+                DispatchQueue.global(qos: .utility).async { [weak self] in
+                    let cards = CardStore.shared.feedCards
+                    DispatchQueue.main.async {
+                        guard let self = self else { return }
+                        self.feedCardList?.setCards(cards)
+                        self.feedStackLoading = false
+                        self.feedStackLoaded = true
+                        // Loading cards may switch the empty state from the
+                        // hero orb to the feed list; recompute once data lands.
+                        self.refreshAvatarVisibility(animated: false)
+                    }
+                }
             }
         } else {
             feedStackLoaded = false

--- a/LoopIOS/MessagingVC.swift
+++ b/LoopIOS/MessagingVC.swift
@@ -470,7 +470,12 @@ When the user asks how you work, what you can do, or how you're built, read `ABO
 
         // Hand the harness a reference back to us so /new, /reset, and /compact
         // can apply UI-level side effects without the harness depending on UIKit.
-        AgentHarness.shared.slashCommandHost = self
+        let agentHarness = AgentHarness.shared
+        agentHarness.slashCommandHost = self
+        // Workspace documents and skills may still be iCloud placeholders on
+        // a new phone. Hydrate them in the background while the basic chat UI
+        // below is constructed immediately.
+        agentHarness.startPersistenceBootstrap()
         // ImageGenerationService injects placeholder + final image messages
         // into the chat as the long-running HTTP request progresses; route
         // those through us so the bubble updates in place.

--- a/LoopMac/HotKeyMonitor.swift
+++ b/LoopMac/HotKeyMonitor.swift
@@ -2,7 +2,7 @@
 //  HotKeyMonitor.swift
 //  LoopMac
 //
-//  Listens for the control + fn modifier combo across the whole system. We
+//  Listens for the shift + control modifier combo across the whole system. We
 //  use NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged) so the user
 //  can trigger Loop from any app, not just when Loop is frontmost.
 //
@@ -28,7 +28,7 @@ final class HotKeyMonitor {
     private var combinationActive = false
     private var holdTimer: Timer?
     private var holdFired = false
-    /// How long the user must hold ctrl+fn before we treat the press as a
+    /// How long the user must hold shift+control before we treat the press as a
     /// "hold to record" rather than a "tap to type." 200ms is short enough
     /// that recording still feels immediate but long enough that a quick
     /// chord doesn't accidentally start the mic.
@@ -56,9 +56,9 @@ final class HotKeyMonitor {
 
     private func handle(event: NSEvent) {
         let flags = event.modifierFlags
-        // We want the press where BOTH control and function are held; release
+        // We want the press where BOTH shift and control are held; release
         // on either coming up.
-        let comboHeld = flags.contains(.control) && flags.contains(.function)
+        let comboHeld = flags.contains(.shift) && flags.contains(.control)
         if comboHeld && !combinationActive {
             combinationActive = true
             holdFired = false

--- a/LoopMac/Info.plist
+++ b/LoopMac/Info.plist
@@ -22,9 +22,9 @@
 	<key>LSUIElement</key>
 	<false/>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>Loop records your voice when you hold control + fn so it can transcribe and send it to the assistant.</string>
+	<string>Loop records your voice when you hold shift + control so it can transcribe and send it to the assistant.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>
-	<string>Loop transcribes your speech when you hold control + fn so the assistant can hear what you say.</string>
+	<string>Loop transcribes your speech when you hold shift + control so the assistant can hear what you say.</string>
 	<key>NSCalendarsFullAccessUsageDescription</key>
 	<string>Loop reads your calendar to answer schedule questions and drafts new events for you to review before saving.</string>
 	<key>NSAppleMusicUsageDescription</key>

--- a/LoopMac/Onboarding/HotkeyVisualView.swift
+++ b/LoopMac/Onboarding/HotkeyVisualView.swift
@@ -2,7 +2,7 @@
 //  HotkeyVisualView.swift
 //  LoopMac
 //
-//  Animated illustration of the fn + ⌃ hold-to-talk hotkey shown during
+//  Animated illustration of the shift + ⌃ hold-to-talk hotkey shown during
 //  onboarding's first-command step. Two key caps press down in sequence,
 //  hold, then release — looping so the user can imitate it.
 //
@@ -12,11 +12,7 @@ import QuartzCore
 
 final class HotkeyVisualView: NSView {
 
-    /// Faded "shift" cap above and left-aligned to fn. Never pressed —
-    /// it's a static orientation cue ("you're in the bottom-left corner of
-    /// the keyboard"), not part of the chord.
-    private let shiftKey = KeyCapView(glyph: "shift", labelPosition: .bottomLeading)
-    private let fnKey = KeyCapView(glyph: "fn")
+    private let shiftKey = KeyCapView(glyph: "shift")
     private let ctrlKey = KeyCapView(glyph: "⌃")
     private let plusLabel = NSTextField(labelWithString: "+")
     private var cycleTimer: Timer?
@@ -26,10 +22,10 @@ final class HotkeyVisualView: NSView {
     /// is true the corresponding cap is pinned in the pressed state and the
     /// animation cycle skips over it — releasing returns control to the
     /// animation.
-    private var realFnHeld = false {
+    private var realShiftHeld = false {
         didSet {
-            guard oldValue != realFnHeld else { return }
-            fnKey.setPressed(realFnHeld)
+            guard oldValue != realShiftHeld else { return }
+            shiftKey.setPressed(realShiftHeld)
         }
     }
     private var realCtrlHeld = false {
@@ -49,32 +45,18 @@ final class HotkeyVisualView: NSView {
         plusLabel.textColor = .tertiaryLabelColor
         plusLabel.translatesAutoresizingMaskIntoConstraints = false
 
-        let pressedRow = NSStackView(views: [fnKey, plusLabel, ctrlKey])
+        let pressedRow = NSStackView(views: [shiftKey, plusLabel, ctrlKey])
         pressedRow.orientation = .horizontal
         pressedRow.alignment = .centerY
         pressedRow.spacing = 14
         pressedRow.translatesAutoresizingMaskIntoConstraints = false
         addSubview(pressedRow)
 
-        shiftKey.translatesAutoresizingMaskIntoConstraints = false
-        // Faded so it reads as "context, not the keys to press".
-        shiftKey.alphaValue = 0.35
-        addSubview(shiftKey)
-
         NSLayoutConstraint.activate([
             // Pressed row sits along the bottom of our bounds and is
             // horizontally centered.
             pressedRow.centerXAnchor.constraint(equalTo: centerXAnchor),
-            pressedRow.bottomAnchor.constraint(equalTo: bottomAnchor),
-
-            // shift sits a row up and spans from fn's leading edge to ctrl's
-            // trailing edge — mimics the wide shift key on a real Mac
-            // keyboard. Required constraints override the cap's intrinsic
-            // width (56pt) so it stretches.
-            shiftKey.leadingAnchor.constraint(equalTo: fnKey.leadingAnchor),
-            shiftKey.trailingAnchor.constraint(equalTo: ctrlKey.trailingAnchor),
-            shiftKey.bottomAnchor.constraint(equalTo: fnKey.topAnchor, constant: -8),
-            shiftKey.topAnchor.constraint(greaterThanOrEqualTo: topAnchor),
+            pressedRow.centerYAnchor.constraint(equalTo: centerYAnchor),
         ])
     }
 
@@ -101,7 +83,7 @@ final class HotkeyVisualView: NSView {
     private func startAnimating() {
         stopAnimating()
         runCycle()
-        // 3.6s per cycle: 0.4 idle, fn down at 0.4, ctrl down at 0.75, hold,
+        // 3.6s per cycle: 0.4 idle, shift down at 0.4, ctrl down at 0.75, hold,
         // both release at 2.6, brief idle, loop.
         cycleTimer = Timer.scheduledTimer(withTimeInterval: 3.6, repeats: true) { [weak self] _ in
             self?.runCycle()
@@ -116,21 +98,21 @@ final class HotkeyVisualView: NSView {
         // Only reset caps that aren't currently being held for real. Otherwise
         // the next viewDidMoveToWindow could blip them out of the pressed
         // state while the user's finger is still on the key.
-        if !realFnHeld { fnKey.setPressed(false, animated: false) }
+        if !realShiftHeld { shiftKey.setPressed(false, animated: false) }
         if !realCtrlHeld { ctrlKey.setPressed(false, animated: false) }
     }
 
     private func runCycle() {
         schedule(after: 0.40) {
-            guard !self.realFnHeld else { return }
-            self.fnKey.setPressed(true)
+            guard !self.realShiftHeld else { return }
+            self.shiftKey.setPressed(true)
         }
         schedule(after: 0.75) {
             guard !self.realCtrlHeld else { return }
             self.ctrlKey.setPressed(true)
         }
         schedule(after: 2.60) {
-            if !self.realFnHeld { self.fnKey.setPressed(false) }
+            if !self.realShiftHeld { self.shiftKey.setPressed(false) }
             if !self.realCtrlHeld { self.ctrlKey.setPressed(false) }
         }
     }
@@ -167,7 +149,7 @@ final class HotkeyVisualView: NSView {
     }
 
     private func applyFlags(_ flags: NSEvent.ModifierFlags) {
-        realFnHeld = flags.contains(.function)
+        realShiftHeld = flags.contains(.shift)
         realCtrlHeld = flags.contains(.control)
     }
 }
@@ -175,18 +157,7 @@ final class HotkeyVisualView: NSView {
 /// Single key cap. The cap layer sits raised above a darker base; on press
 /// it slides down to flush with the base, mimicking a keyboard keycap being
 /// held down. The text glyph lives inside the cap so it tracks the motion.
-///
-/// Layout is bounds-driven (not constant-driven), so a caller can stretch
-/// a cap with autolayout — used to make the shift cap span the row.
 private final class KeyCapView: NSView {
-
-    enum LabelPosition {
-        /// Glyph centered inside the cap (default for fn / ⌃).
-        case center
-        /// Glyph nudged into the bottom-left corner, like the "shift" label
-        /// on a real Mac shift key. Used for the orientation cue.
-        case bottomLeading
-    }
 
     private let intrinsicWidth: CGFloat = 56
     private let intrinsicHeight: CGFloat = 56
@@ -196,10 +167,8 @@ private final class KeyCapView: NSView {
     private let capLayer = CALayer()
     private let textLayer = CATextLayer()
     private var pressed = false
-    private let labelPosition: LabelPosition
 
-    init(glyph: String, labelPosition: LabelPosition = .center) {
-        self.labelPosition = labelPosition
+    init(glyph: String) {
         super.init(frame: NSRect(x: 0, y: 0, width: 56, height: 56))
         wantsLayer = true
         layer?.masksToBounds = false
@@ -214,7 +183,7 @@ private final class KeyCapView: NSView {
         textLayer.string = glyph
         textLayer.font = NSFont.systemFont(ofSize: 18, weight: .medium)
         textLayer.fontSize = 18
-        textLayer.alignmentMode = labelPosition == .center ? .center : .left
+        textLayer.alignmentMode = .center
         textLayer.truncationMode = .none
         textLayer.contentsScale = NSScreen.main?.backingScaleFactor ?? 2.0
         capLayer.addSublayer(textLayer)
@@ -233,33 +202,19 @@ private final class KeyCapView: NSView {
         let capH = max(0, bounds.height - liftAmount)
         let capW = bounds.width
 
-        // Layout runs whenever bounds change (e.g. shift stretched across the
-        // row). Disable implicit animations so the resize is instantaneous;
-        // press animations have their own transaction in setPressed.
+        // Disable implicit animations so layout is instantaneous; press
+        // animations have their own transaction in setPressed.
         CATransaction.begin()
         CATransaction.setDisableActions(true)
         baseLayer.frame = CGRect(x: 0, y: 0, width: capW, height: capH)
         capLayer.frame = CGRect(x: 0, y: pressed ? 0 : liftAmount, width: capW, height: capH)
         let textHeight: CGFloat = 22
-        switch labelPosition {
-        case .center:
-            textLayer.frame = CGRect(
-                x: 0,
-                y: (capH - textHeight) / 2,
-                width: capW,
-                height: textHeight
-            )
-        case .bottomLeading:
-            // Pin to the lower-left corner with a small inset — mirrors how
-            // "shift" is etched at the bottom-left of a real Apple keycap.
-            let inset: CGFloat = 8
-            textLayer.frame = CGRect(
-                x: inset,
-                y: inset - 2, // small visual nudge so it sits tight to bottom
-                width: capW - inset * 2,
-                height: textHeight
-            )
-        }
+        textLayer.frame = CGRect(
+            x: 0,
+            y: (capH - textHeight) / 2,
+            width: capW,
+            height: textHeight
+        )
         CATransaction.commit()
     }
 

--- a/LoopMac/RecorderWindowController.swift
+++ b/LoopMac/RecorderWindowController.swift
@@ -3,7 +3,7 @@
 //  LoopMac
 //
 //  Slim floating bar pinned bottom-center of the active screen, matching
-//  LoopIOS/Specs/mac_recorder.png. Always visible; the user holds control+fn
+//  LoopIOS/Specs/mac_recorder.png. Always visible; the user holds shift+control
 //  from anywhere to record.
 //
 
@@ -381,7 +381,7 @@ final class RecorderWindowController: NSWindowController, NSTextFieldDelegate, N
     }
 
     private func makePlaceholder() -> NSAttributedString {
-        // "Type or hold fn control to speak" with the keys shown as small
+        // "Type or hold shift control to speak" with the keys shown as small
         // pill-buttons. We use attachments + paragraph styling to mirror the
         // mockup as closely as possible.
         let result = NSMutableAttributedString()
@@ -393,7 +393,7 @@ final class RecorderWindowController: NSWindowController, NSTextFieldDelegate, N
             .font: NSFont.systemFont(ofSize: 15),
         ]
         result.append(NSAttributedString(string: "Type or hold ", attributes: baseAttrs))
-        result.append(keyPill("fn"))
+        result.append(keyPill("shift"))
         result.append(NSAttributedString(string: " ", attributes: baseAttrs))
         result.append(keyPill("control"))
         result.append(NSAttributedString(string: " to speak", attributes: baseAttrs))

--- a/LoopMac/VoiceLoopCoordinator.swift
+++ b/LoopMac/VoiceLoopCoordinator.swift
@@ -262,7 +262,7 @@ final class VoiceLoopCoordinator {
         let prompt = """
 You are an AI called Loop designed to be a living memory.
 
-The user is on macOS, talking to you with hold-to-talk via control+fn from anywhere on their system. The same conversation continues seamlessly on the Loop iPhone app — every tool you have here is also available there, and vice versa.
+The user is on macOS, talking to you with hold-to-talk via shift+control from anywhere on their system. The same conversation continues seamlessly on the Loop iPhone app — every tool you have here is also available there, and vice versa.
 
 Please keep your responses limited to 30 words and use markdown and emojis as needed to convey your ideas. Leverage bolding as you can.
 

--- a/LoopVision/LoopVisionApp.swift
+++ b/LoopVision/LoopVisionApp.swift
@@ -6,7 +6,7 @@ import SwiftUI
 /// single volumetric window that lives in the visionOS **Shared Space**, so it
 /// floats in your real room (passthrough) alongside every other open app. You
 /// look at the orb and pinch-and-hold to talk — the equivalent of holding
-/// fn+control on the Mac.
+/// shift+control on the Mac.
 ///
 /// Why a volume and not an `ImmersiveSpace`: opening *any* immersive space
 /// (even a `.mixed` passthrough one) moves the wearer into the exclusive Full

--- a/LoopVision/OrbAvatar.swift
+++ b/LoopVision/OrbAvatar.swift
@@ -154,7 +154,7 @@ final class OrbAvatar {
         root.components.set(BillboardComponent())
 
         // Pinch target: the user pinches while looking at the ball (the Vision
-        // equivalent of holding fn+control). A generous collision sphere makes
+        // equivalent of holding shift+control). A generous collision sphere makes
         // it forgiving to aim at even as the ball breathes.
         let reachM = Float(latticeReach) * metersPerGridUnit
         root.components.set(InputTargetComponent())

--- a/LoopVision/OrbVolumeView.swift
+++ b/LoopVision/OrbVolumeView.swift
@@ -12,7 +12,7 @@ import RealityKit
 /// `InputTargetComponent` + `CollisionComponent`, and the pinch gesture below
 /// is `.targetedToEntity(orb.root)`. visionOS only routes the pinch to the orb
 /// while the wearer's gaze is on that collision shape — so a glance plus a
-/// pinch-and-hold is the exact analogue of holding fn+control on the Mac:
+/// pinch-and-hold is the exact analogue of holding shift+control on the Mac:
 /// record while held, send the turn on release.
 ///
 /// All conversation state comes from the shared `VisionSession`; this view
@@ -97,7 +97,7 @@ struct OrbVolumeView: View {
 
     private static let captionID = "caption"
 
-    // MARK: - Pinch-hold gesture (the fn+control equivalent)
+    // MARK: - Pinch-hold gesture (the shift+control equivalent)
 
     /// A zero-distance drag targeted at the orb behaves as press-and-hold:
     /// the first `onChanged` is the pinch-down, `onEnded` is the release.

--- a/LoopVision/VisionVoiceCoordinator.swift
+++ b/LoopVision/VisionVoiceCoordinator.swift
@@ -9,7 +9,7 @@
 //  KeyStore, MessageStruct) are the same LoopIOS/ sources LoopMac compiles.
 //
 //  The pinch gesture is wired to be the exact equivalent of holding
-//  fn+control on the Mac (see LoopMac/HotKeyMonitor): `pinchBegan()` starts
+//  shift+control on the Mac (see LoopMac/HotKeyMonitor): `pinchBegan()` starts
 //  capture, `pinchEnded()` stops it and sends the turn.
 //
 //  Concurrency intentionally mirrors the Mac coordinator: a plain class
@@ -121,7 +121,7 @@ final class VisionVoiceCoordinator {
         loadConversation()
     }
 
-    // MARK: - Pinch gesture entry points (the fn+control equivalent)
+    // MARK: - Pinch gesture entry points (the shift+control equivalent)
 
     /// Called on pinch-down. Idempotent: a held pinch fires the gesture's
     /// `onChanged` repeatedly, but only the first one (while idle/speaking)

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -1,0 +1,281 @@
+# How LoopHarness Works
+
+LoopHarness is the engine behind **Loop**, a native personal assistant for iOS,
+macOS, and visionOS. The short version is:
+
+> A native UI captures a typed or spoken request, saves it locally, gives a
+> model the conversation plus Loop's memory and available tools, executes any
+> tools the model requests, and repeats until the model returns a final answer.
+
+The model is the planner; LoopHarness is the runtime that supplies context,
+executes actions, persists state, and presents the result.
+
+## The system at a glance
+
+```mermaid
+flowchart LR
+    User["User: text, voice, share sheet"] --> Surface["Native app surface<br/>iOS, macOS, or visionOS"]
+    Surface --> Store["Conversation store<br/>NDJSON + iCloud/local cache"]
+    Surface --> Harness["AgentHarness"]
+
+    Workspace["Workspace<br/>SOUL, USER, MEMORY,<br/>AGENTS, tools, files"] --> Harness
+    Keys["Keychain<br/>user-owned API keys"] --> Providers
+    Harness --> Providers["Model provider<br/>OpenAI, Anthropic, Fireworks,<br/>or Apple on-device"]
+
+    Providers -->|"final text"| Surface
+    Providers -->|"tool calls"| Dispatcher["SkillDispatcher"]
+    Dispatcher --> Skills["Bundled skills"]
+    Dispatcher --> Dynamic["User-authored skills"]
+    Dispatcher --> MCP["Remote MCP tools"]
+    Skills -->|"tool results"| Providers
+    Dynamic -->|"tool results"| Providers
+    MCP -->|"tool results"| Providers
+
+    Surface --> Output["Chat bubble, streaming text,<br/>TTS, cards, files, notifications"]
+```
+
+There is no required Loop cloud service in the main local path. Hosted model
+requests go directly from the app to the selected provider using a key stored
+in the user's Keychain. Conversation and workspace data prefer iCloud Drive
+and fall back to local storage when iCloud is unavailable.
+
+## What happens at app launch
+
+The details differ by platform, but all three apps converge on the same shared
+conversation, model, skill, and persistence code.
+
+### iOS
+
+1. [`AppDelegate.swift`](../LoopIOS/AppDelegate.swift) initializes Keychain and
+   iCloud-backed preferences, registers scheduled/background work, starts the
+   runner and remote-message pollers, and wires notification routing.
+2. [`ConversationFileStore.swift`](../LoopIOS/Data/ConversationFileStore.swift)
+   resolves the iCloud conversation folder in the background. It first loads
+   lightweight conversation metadata, then hydrates full message history so
+   startup does not block on iCloud downloads.
+3. [`MessagingVC.swift`](../LoopIOS/MessagingVC.swift) restores the active
+   conversation, connects the message box and voice UI, and starts the agent
+   workspace bootstrap.
+4. [`AgentHarness.swift`](../LoopIOS/AgentHarness/AgentHarness.swift) loads the
+   self-documents and discovers bundled, user-authored, and MCP skills. On iOS
+   this happens asynchronously; a very early chat waits for it without freezing
+   the UI.
+5. When the scene becomes active,
+   [`SceneDelegate.swift`](../LoopIOS/SceneDelegate.swift) reconciles scheduled
+   jobs, drains shared attachments, and starts foreground polling for remote
+   results.
+
+### macOS
+
+[`LoopMacApp.swift`](../LoopMac/LoopMacApp.swift) creates the floating recorder,
+conversation window, global push-to-talk hotkey, and Mac-only skills such as app
+launching and terminal control. A per-conversation
+[`VoiceLoopCoordinator.swift`](../LoopMac/VoiceLoopCoordinator.swift) then drives
+voice and text turns through the shared harness.
+
+### visionOS
+
+[`LoopVisionApp.swift`](../LoopVision/LoopVisionApp.swift) creates a volumetric
+orb and a separate conversation window backed by one shared session.
+Pinch-and-hold voice input flows through
+[`VisionVoiceCoordinator.swift`](../LoopVision/VisionVoiceCoordinator.swift) and
+then into the same harness and conversation store.
+
+## What happens during a normal turn
+
+The primary path below is implemented by
+[`MessagingVC.swift`](../LoopIOS/MessagingVC.swift),
+[`Cloud.swift`](../LoopIOS/Data/Cloud.swift), and
+[`AgentHarness.swift`](../LoopIOS/AgentHarness/AgentHarness.swift). `Cloud` is a
+small compatibility shim; `AgentHarness` owns the actual routing.
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant UI as Native conversation UI
+    participant Store as Conversation store
+    participant Harness as AgentHarness
+    participant Model as Selected model
+    participant Tools as SkillDispatcher / skill
+
+    User->>UI: Send text, transcript, or attachment
+    UI->>Store: Persist user message immediately
+    UI->>Harness: Send persisted conversation context
+    Harness->>Harness: Load self-docs and select relevant tools
+    Harness->>Model: System prompt + history + tool schemas
+    Model-->>UI: Stream partial response text
+
+    alt Model asks to use tools
+        Model->>UI: Return one or more tool calls
+        UI->>Store: Persist assistant tool-call message
+        par Tool calls can run concurrently
+            UI->>Tools: Dispatch tool call A
+            UI->>Tools: Dispatch tool call B
+        end
+        Tools-->>Store: Persist function results
+        UI->>Harness: Send updated conversation back to model
+        Note over Harness,Tools: This loop repeats until there are no tool calls
+    else Model returns final text
+        Model-->>UI: Final assistant message
+    end
+
+    UI->>Store: Persist final assistant message
+    UI-->>User: Render bubble; optionally speak or notify
+```
+
+In more concrete terms:
+
+1. **Capture and persist.** The UI creates a `MessageStruct`, attaches any file
+   or speech-engine metadata, and writes it to the current conversation before
+   inference begins. This makes the user's input durable even if the request
+   later fails.
+2. **Build context.** The harness combines conversation history with a system
+   prompt assembled from `SOUL.md`, `USER.md`, `MEMORY.md`, `AGENTS.md`,
+   `HEARTBEAT.md`, and the available tool descriptions. These workspace files
+   are meant to make the assistant inspectable and editable.
+3. **Reduce the tool set.** [`ToolRouter.swift`](../LoopIOS/AgentHarness/ToolRouter.swift)
+   chooses the skill groups relevant to the latest request so every call does
+   not carry the full catalog. Ambiguous requests can still receive the broad
+   set.
+4. **Choose a model route.** Online requests go directly to the selected
+   OpenAI, Anthropic, or Fireworks client. Apple Foundation Models are used
+   when selected or when the device is offline and the on-device model is
+   available. If an attachment needs vision and the chosen model cannot see
+   images, that turn can be routed to a vision-capable model.
+5. **Stream and inspect the response.** Plain assistant text ends the loop. A
+   response containing function calls enters the tool path instead.
+6. **Execute tools.** [`SkillDispatcher.swift`](../LoopIOS/AgentHarness/SkillDispatcher.swift)
+   routes each call to a bundled skill, a Mac-only registered handler, a
+   user-authored dynamic skill, or an MCP server. Multiple calls from one model
+   response can run in parallel in the main chat flow.
+7. **Guard against loops.** [`ToolCallGuard.swift`](../LoopIOS/AgentHarness/ToolCallGuard.swift)
+   can block repeated calls and return a structured result to the model instead
+   of allowing an accidental tool loop to consume time and quota.
+8. **Continue the loop.** Tool results are saved as function messages and the
+   expanded conversation is sent back through the harness. The model may ask
+   for more tools or return its final answer.
+9. **Finish.** The final message is saved and rendered. The active surface can
+   speak a sanitized version with TTS; if the app is backgrounded, iOS can post
+   a completion notification instead.
+
+## Where state lives
+
+| State | Storage | Purpose |
+| --- | --- | --- |
+| Conversations | One NDJSON file per conversation in iCloud Drive, with a local fallback | Durable chat history shared across Apple devices |
+| Agent self-documents and files | Sandboxed iCloud workspace, with a local Documents fallback | Editable identity, user context, memory, skills, and generated files |
+| API keys and remote secrets | Apple Keychain | Provider credentials and SSH secrets |
+| Lightweight preferences and scheduler records | `UserDefaults` / iCloud key-value preferences where applicable | Model, voice, UI, backend, and scheduled-job settings |
+| Portable runner state | SQLite on the VM | Remote turns and tool jobs that survive runner restarts |
+
+[`Workspace.swift`](../LoopIOS/Workspace/Workspace.swift) is the safety boundary
+for agent-visible files: paths are resolved relative to the workspace, traversal
+is rejected, and individual reads/writes are capped at 1 MB.
+
+[`ConversationStore.swift`](../LoopIOS/Data/ConversationStore.swift) abstracts
+where a conversation lives. The default implementation is the local/iCloud
+file store. A conversation may instead belong to a configured remote execution
+backend, and the router keeps conversations isolated by their owning backend.
+
+## The important alternate paths
+
+### Voice input and output
+
+Voice is an input/output layer around the same turn loop:
+
+```text
+hold/tap gesture -> microphone recording -> STT -> user MessageStruct
+                 -> normal agent/tool loop -> final text -> sanitize -> TTS
+```
+
+Deepgram and Apple speech recognition are supported by the shared speech
+pipeline. TTS is also provider-selectable. The conversation remains text at
+rest, so typed and spoken turns share the same history.
+
+### Sub-agents
+
+A model can call the sub-agent skill for a focused background task.
+[`SubAgentManager.swift`](../LoopIOS/SubAgents/SubAgentManager.swift) creates and
+tracks the child, while
+[`SubAgentRuntime.swift`](../LoopIOS/SubAgents/SubAgentRuntime.swift) gives it a
+scoped prompt and runs its own model/tool loop. Its private working transcript
+does not become the main chat; when it finishes, a summary is posted back to
+the parent conversation. Research/general agents have runtime limits, while
+coding agents are designed to continue until completion or manual cancellation.
+
+### Scheduled work
+
+[`BackgroundScheduler.swift`](../LoopIOS/Skills/Scheduler/BackgroundScheduler.swift)
+stores jobs and pre-generates results near their notification time. macOS uses
+timers; iOS combines notifications, `BGProcessingTask`, and a foreground
+catch-up path because iOS background execution is opportunistic. A prefetched
+result is written to a conversation, and tapping its notification opens that
+result; if prefetch did not run, the app can execute the prompt live.
+
+### Remote OpenClaw conversations
+
+The user can select an SSH VM execution backend. New conversations created
+while it is active belong to that backend. Messages and transcripts are routed
+through [`OpenClawConversationStore.swift`](../LoopIOS/Data/OpenClawConversationStore.swift),
+and the app streams through a gateway connection or polls the remote transcript
+instead of starting local model inference. Switching backends changes which
+conversation list is shown; it does not move or merge conversations.
+
+### Portable Go runner and background handoff
+
+The optional runner under [`runtime/go/`](../runtime/go/) is a smaller, portable
+agent runtime for a VM. It is separate from the much larger native skill
+catalog.
+
+On startup, [`main.go`](../runtime/go/main.go) loads configuration, opens a
+SQLite database, registers its tools, and exposes authenticated HTTP endpoints.
+For `POST /turn`, [`agent.go`](../runtime/go/agent/agent.go) calls OpenAI,
+streams text, dispatches requested tools, and repeats until it has a final
+answer. Local runner tools execute in-process; device-tagged tools go through a
+device bridge.
+
+The iOS app can hand an in-flight local turn to this runner when the app truly
+enters the background:
+
+```mermaid
+sequenceDiagram
+    participant iOS as iOS app
+    participant Runner as Go runner
+    participant DB as Runner SQLite
+    participant Push as Push / foreground polling
+
+    iOS->>Runner: POST /turn with async=true
+    Runner->>DB: Create running turn
+    Runner-->>iOS: 202 + turn id
+    iOS->>iOS: Mark local result disposable
+    Runner->>Runner: Finish model/tool loop after client disconnects
+    Runner->>DB: Save final response
+    Runner-->>Push: Completion signal (best effort)
+    Push-->>iOS: Notify, or iOS discovers result by polling
+    iOS->>Runner: Fetch completed turn
+    Runner-->>iOS: Final response
+    iOS->>iOS: Insert reply exactly once into original conversation
+```
+
+The runner currently has only `echo` and `web_fetch` as working local tools.
+Its `read_calendar` device route and direct APNs bridge are scaffolding unless
+the missing push/device pieces are configured and implemented. Polling the
+runner's `/turns` and `/jobs` endpoints is the dependable result-recovery
+path.
+
+## A useful mental model
+
+Think of LoopHarness as five cooperating layers:
+
+1. **Surface** — native chat, orb, recorder, share sheet, notifications.
+2. **State** — conversations, memory documents, workspace files, preferences,
+   and credentials.
+3. **Harness** — prompt composition, model selection, context management, and
+   tool-schema selection.
+4. **Action loop** — model requests tools; dispatchers run them; results return
+   to the model until it is done.
+5. **Background/remote execution** — sub-agents, scheduling, OpenClaw backends,
+   and the optional portable runner keep work going outside a foreground turn.
+
+Most new capabilities fit into one of two places: a new **surface** that feeds
+the shared turn loop, or a new **skill** that the model can call from that loop.


### PR DESCRIPTION
## Summary

- move iOS workspace/self-document bootstrap and feed-card loading off the main thread so a newly configured device can present a usable chat UI while iCloud state hydrates
- change the macOS hold-to-talk chord from Control+Fn to Shift+Control and update onboarding, permission copy, prompts, and cross-platform references consistently
- add an architecture guide covering launch, model/tool turns, persistence, voice, sub-agents, scheduling, remote backends, and the portable runner

## Why

Launch-time iCloud workspace resolution and file hydration could block UI construction on a new iPhone. The bootstrap now runs on a serial utility queue, and an early chat waits asynchronously for persistence to become ready. The shortcut UI and supporting text also now match the actual Shift+Control behavior everywhere.

## Impact

- faster, non-blocking first-launch behavior on iOS
- consistent macOS shortcut behavior and onboarding guidance
- a discoverable system-level reference for contributors

## Validation

- `git diff --check`
- `xcodebuild -project Loop.xcodeproj -scheme Loop_iOS -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project Loop.xcodeproj -scheme Loop_MacOS -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project Loop.xcodeproj -scheme Loop_VisionOS -configuration Debug -destination 'generic/platform=visionOS Simulator' CODE_SIGNING_ALLOWED=NO build`
