### PR TITLE
Add Amazon Bedrock support and update Kimi K3

### DIFF
--- a/LoopIOS/AgentHarness/AgentHarness.swift
+++ b/LoopIOS/AgentHarness/AgentHarness.swift
@@ -546,6 +546,8 @@ final class AgentHarness {
         switch routeProvider {
         case .anthropic:
             AnthropicChat.shared.chat(messages: rebuilt, tools: toolsToSend, modelIDOverride: modelIDOverride, modelStampOverride: modelStampOverride, onPartial: onPartial, completion: completion)
+        case .bedrock:
+            BedrockChat.shared.chat(messages: rebuilt, tools: toolsToSend, modelIDOverride: modelIDOverride, modelStampOverride: modelStampOverride, onPartial: onPartial, completion: completion)
         case .openAI:
             OpenAIChat.shared.chat(messages: rebuilt, tools: toolsToSend, modelIDOverride: modelIDOverride, modelStampOverride: modelStampOverride, onPartial: onPartial, completion: completion)
         case .fireworks:

--- a/LoopIOS/Data/AnthropicChat.swift
+++ b/LoopIOS/Data/AnthropicChat.swift
@@ -164,7 +164,7 @@ final class AnthropicChat {
     /// Skills declare tools in OpenAI's `{"type":"function","function":{name,
     /// description, parameters}}` shape. Anthropic wants flat
     /// `{name, description, input_schema}`.
-    private static func anthropicTools(from tools: [[String: Any]]) -> [[String: Any]] {
+    static func anthropicTools(from tools: [[String: Any]]) -> [[String: Any]] {
         var seen = Set<String>()
         var out: [[String: Any]] = []
         for tool in tools {
@@ -194,7 +194,7 @@ final class AnthropicChat {
     /// `callId` so multi-call sequences round-trip correctly. Legacy messages
     /// without a `callId` fall back to plain prose so older persisted chats
     /// keep working.
-    private static func wirePayload(from messages: [MessageStruct]) -> (String?, [[String: Any]]) {
+    static func wirePayload(from messages: [MessageStruct]) -> (String?, [[String: Any]]) {
         var systemParts: [String] = []
         // Intermediate: (role, content blocks). Always block arrays so a text
         // turn and an image turn can be merged uniformly when coalescing.

--- a/LoopIOS/Data/AnthropicStreamReader.swift
+++ b/LoopIOS/Data/AnthropicStreamReader.swift
@@ -22,6 +22,7 @@ final class AnthropicStreamReader: NSObject, URLSessionDataDelegate {
 
     private let completion: (Swift.Result<Result, Error>) -> Void
     private var metrics: InferenceMetrics
+    private let serviceName: String
     /// Fired on the URLSession delegate queue with each text delta as it
     /// arrives. Held strongly — see `SSEStreamReader.onDelta`.
     private let onDelta: ((String) -> Void)?
@@ -50,9 +51,11 @@ final class AnthropicStreamReader: NSObject, URLSessionDataDelegate {
     private var receivedFirstChunk = false
 
     init(metrics: InferenceMetrics,
+         serviceName: String = "Anthropic",
          onDelta: ((String) -> Void)? = nil,
          completion: @escaping (Swift.Result<Result, Error>) -> Void) {
         self.metrics = metrics
+        self.serviceName = serviceName
         self.onDelta = onDelta
         self.completion = completion
     }
@@ -68,7 +71,7 @@ final class AnthropicStreamReader: NSObject, URLSessionDataDelegate {
             completion(.failure(NSError(
                 domain: "AnthropicStreamReader",
                 code: http.statusCode,
-                userInfo: [NSLocalizedDescriptionKey: "HTTP \(http.statusCode) from Anthropic"])))
+                userInfo: [NSLocalizedDescriptionKey: "HTTP \(http.statusCode) from \(serviceName)"])))
             return
         }
         completionHandler(.allow)

--- a/LoopIOS/Data/BedrockChat.swift
+++ b/LoopIOS/Data/BedrockChat.swift
@@ -1,0 +1,156 @@
+//
+//  BedrockChat.swift
+//  Loop
+//
+//  Amazon Bedrock client for Claude models. Bedrock Mantle exposes the native
+//  Anthropic Messages API, so this path deliberately shares AnthropicChat's
+//  message/tool mapping and AnthropicStreamReader. The only provider-specific
+//  pieces are the regional endpoint, Bedrock model IDs, and API key.
+//
+
+import Foundation
+
+final class BedrockChat {
+
+    static let shared = BedrockChat()
+    static let defaultRegion = "us-east-1"
+
+    private init() {}
+
+    private lazy var streamingSessionDelegate = StreamingSessionDelegateRouter()
+    private lazy var streamingSession: URLSession = {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 120
+        config.timeoutIntervalForResource = 180
+        config.waitsForConnectivity = true
+        return URLSession(configuration: config,
+                          delegate: streamingSessionDelegate,
+                          delegateQueue: nil)
+    }()
+
+    private let anthropicVersion = "2023-06-01"
+    private let maxTokens = 4096
+
+    func chat(messages: [MessageStruct],
+              tools: [[String: Any]]? = nil,
+              modelIDOverride: String? = nil,
+              modelStampOverride: String? = nil,
+              onPartial: ((String) -> Void)? = nil,
+              completion: @escaping (MessageStruct?, Error?) -> Void) {
+
+        guard let apiKey = KeyStore.shared.value(for: .bedrock),
+              !apiKey.isEmpty else {
+            completion(nil, Self.error(
+                "Amazon Bedrock is selected but no Bedrock API key is set. Add AWS_BEARER_TOKEN_BEDROCK in Settings ▸ Keys, or switch the model in Settings ▸ Model."))
+            return
+        }
+
+        let configuredRegion = KeyStore.shared.value(for: .bedrockRegion)
+        guard configuredRegion?.isEmpty != false || Self.normalizedRegion(configuredRegion) != nil else {
+            completion(nil, Self.error(
+                "The Amazon Bedrock region is invalid. Use an AWS region such as us-east-1 in Settings ▸ Keys ▸ Amazon Bedrock."))
+            return
+        }
+        let region = Self.normalizedRegion(configuredRegion) ?? Self.defaultRegion
+        guard let endpoint = Self.endpoint(for: region) else {
+            completion(nil, Self.error("Failed to build the Amazon Bedrock endpoint."))
+            return
+        }
+
+        let modelID = modelIDOverride
+            ?? ModelSelectionStore.current.apiModelID
+            ?? "anthropic.claude-opus-4-8"
+        let body = Self.requestBody(messages: messages, tools: tools, modelID: modelID,
+                                    maxTokens: maxTokens)
+        guard let payload = try? JSONSerialization.data(withJSONObject: body) else {
+            completion(nil, Self.error("Failed to encode the Amazon Bedrock request body."))
+            return
+        }
+
+        var metrics = InferenceMetrics(provider: "Amazon Bedrock",
+                                       model: modelID,
+                                       toolCount: (tools ?? []).count)
+        metrics.didBuildPayload(bytes: payload.count)
+
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        request.setValue(anthropicVersion, forHTTPHeaderField: "anthropic-version")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = payload
+        request.timeoutInterval = 120
+
+        metrics.willSendRequest()
+
+        let reader = AnthropicStreamReader(
+            metrics: metrics,
+            serviceName: "Amazon Bedrock",
+            onDelta: onPartial
+        ) { result in
+            switch result {
+            case .success(let response):
+                completion(MessageStruct(
+                    role: "assistant",
+                    content: response.content,
+                    model: modelStampOverride ?? ModelSelectionStore.current.stampedMessageModel,
+                    functions: response.toolCalls,
+                    tokenUsage: response.usage,
+                    ttft: response.ttft), nil)
+            case .failure(let error):
+                completion(nil, Self.error(
+                    "Amazon Bedrock streaming error: \(error.localizedDescription)"))
+            }
+        }
+
+        let task = streamingSession.dataTask(with: request)
+        streamingSessionDelegate.register(task: task, reader: reader)
+        LocalInferenceController.shared.track(task)
+        task.resume()
+    }
+
+    static func requestBody(messages: [MessageStruct],
+                            tools: [[String: Any]]?,
+                            modelID: String,
+                            maxTokens: Int = 4096) -> [String: Any] {
+        let (system, wireMessages) = AnthropicChat.wirePayload(from: messages)
+        var body: [String: Any] = [
+            "model": modelID,
+            "max_tokens": maxTokens,
+            "messages": wireMessages,
+            "stream": true,
+        ]
+        if let system, !system.isEmpty {
+            body["system"] = system
+        }
+        if let tools, !tools.isEmpty {
+            body["tools"] = AnthropicChat.anthropicTools(from: tools)
+            body["tool_choice"] = ["type": "auto"]
+        }
+        return body
+    }
+
+    /// Keep the region constrained to a hostname-safe AWS region token. The
+    /// endpoint host is always owned by AWS; a stored value cannot redirect
+    /// requests (and the API key) to another domain.
+    static func normalizedRegion(_ raw: String?) -> String? {
+        guard let value = raw?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+              !value.isEmpty,
+              value.count <= 32,
+              value.first != "-",
+              value.last != "-",
+              value.allSatisfy({ $0.isLowercase || $0.isNumber || $0 == "-" }) else {
+            return nil
+        }
+        return value
+    }
+
+    static func endpoint(for region: String) -> URL? {
+        guard let safeRegion = normalizedRegion(region) else { return nil }
+        return URL(string: "https://bedrock-mantle.\(safeRegion).api.aws/anthropic/v1/messages")
+    }
+
+    private static func error(_ message: String) -> NSError {
+        NSError(domain: "BedrockChat", code: -1,
+                userInfo: [NSLocalizedDescriptionKey: message])
+    }
+}

--- a/LoopIOS/Data/BedrockChat.swift
+++ b/LoopIOS/Data/BedrockChat.swift
@@ -59,7 +59,7 @@ final class BedrockChat {
 
         let modelID = modelIDOverride
             ?? ModelSelectionStore.current.apiModelID
-            ?? "anthropic.claude-opus-4-8"
+            ?? "anthropic.claude-opus-5"
         let body = Self.requestBody(messages: messages, tools: tools, modelID: modelID,
                                     maxTokens: maxTokens)
         guard let payload = try? JSONSerialization.data(withJSONObject: body) else {

--- a/LoopIOS/Data/ConversationTitleService.swift
+++ b/LoopIOS/Data/ConversationTitleService.swift
@@ -54,7 +54,7 @@ final class ConversationTitleService {
     /// - There isn't a real user-AND-assistant exchange yet (e.g., still
     ///   in onboarding, or assistant turn was tool-only).
     /// - A request is already in flight for this id.
-    /// - No provider key (Anthropic or OpenAI) is configured.
+    /// - No provider key is configured and Apple Foundation is unavailable.
     ///
     /// Pass `preserveCustomTitle: false` for the periodic refresh path so
     /// previously-auto-generated titles get updated as the conversation's
@@ -175,7 +175,7 @@ final class ConversationTitleService {
         // their cloud key was cleared). Try the cheap-cloud fallbacks in
         // order, then on-device. This way someone on Apple still gets a
         // title via Haiku if they happen to have an Anthropic key paste'd.
-        for fallback in [ModelProvider.anthropic, .openAI, .fireworks, .apple] {
+        for fallback in [ModelProvider.anthropic, .bedrock, .openAI, .fireworks, .apple] {
             if fallback == preferred { continue }
             if let p = provider(for: fallback) { return p }
         }
@@ -193,6 +193,13 @@ final class ConversationTitleService {
         case .anthropic:
             if let key = KeyStore.shared.value(for: .anthropic), !key.isEmpty {
                 return .anthropic(key: key)
+            }
+            return nil
+        case .bedrock:
+            if let key = KeyStore.shared.value(for: .bedrock), !key.isEmpty {
+                let region = BedrockChat.normalizedRegion(KeyStore.shared.value(for: .bedrockRegion))
+                    ?? BedrockChat.defaultRegion
+                return .bedrock(key: key, region: region)
             }
             return nil
         case .openAI:
@@ -305,6 +312,7 @@ final class ConversationTitleService {
 /// keys during the request window).
 private enum TitleProvider {
     case anthropic(key: String)
+    case bedrock(key: String, region: String)
     case openAI(key: String)
     case fireworks(key: String)
     /// On-device via FoundationModels. No key, no network — slower than the
@@ -317,6 +325,9 @@ private enum TitleProvider {
         switch self {
         case .anthropic(let key):
             Self.sendAnthropic(key: key, snippet: snippet, session: session, completion: completion)
+        case .bedrock(let key, let region):
+            Self.sendBedrock(key: key, region: region, snippet: snippet,
+                             session: session, completion: completion)
         case .openAI(let key):
             Self.sendOpenAI(key: key, snippet: snippet, session: session, completion: completion)
         case .fireworks(let key):
@@ -373,6 +384,50 @@ Title this conversation in 3-5 words:
                   let content = json["content"] as? [[String: Any]],
                   let first = content.first,
                   let text = first["text"] as? String else {
+                completion(nil); return
+            }
+            completion(text)
+        }
+        task.resume()
+    }
+
+    // MARK: Amazon Bedrock (Claude Opus 4.7)
+
+    private static func sendBedrock(key: String,
+                                    region: String,
+                                    snippet: String,
+                                    session: URLSession,
+                                    completion: @escaping (String?) -> Void) {
+        guard let url = BedrockChat.endpoint(for: region) else {
+            completion(nil); return
+        }
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue(key, forHTTPHeaderField: "x-api-key")
+        req.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let body: [String: Any] = [
+            "model": "anthropic.claude-opus-4-7",
+            "max_tokens": 32,
+            "system": systemPrompt,
+            "messages": [
+                ["role": "user", "content": userInstruction + snippet],
+            ],
+        ]
+        req.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        let task = session.dataTask(with: req) { data, response, error in
+            if let error {
+                print("TitleService Amazon Bedrock error: \(error.localizedDescription)")
+                completion(nil); return
+            }
+            if let http = response as? HTTPURLResponse, http.statusCode >= 400 {
+                print("TitleService Amazon Bedrock HTTP \(http.statusCode)")
+                completion(nil); return
+            }
+            guard let data,
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let content = json["content"] as? [[String: Any]],
+                  let text = content.first(where: { ($0["type"] as? String) == "text" })?["text"] as? String else {
                 completion(nil); return
             }
             completion(text)

--- a/LoopIOS/Data/ModelSelection.swift
+++ b/LoopIOS/Data/ModelSelection.swift
@@ -99,6 +99,7 @@ enum ModelSelection: String, CaseIterable {
     case claudeHaiku45  = "claudeHaiku45"
 
     // Amazon Bedrock Mantle — Claude via the user's Bedrock API key.
+    case bedrockOpus5  = "bedrockOpus5"
     case bedrockOpus48 = "bedrockOpus48"
     case bedrockOpus47 = "bedrockOpus47"
 
@@ -115,7 +116,7 @@ enum ModelSelection: String, CaseIterable {
             return .openAI
         case .claudeOpus47, .claudeSonnet46, .claudeHaiku45:
             return .anthropic
-        case .bedrockOpus48, .bedrockOpus47:
+        case .bedrockOpus5, .bedrockOpus48, .bedrockOpus47:
             return .bedrock
         case .fireworksKimiK3, .fireworksKimiK26, .fireworksGLM52:
             return .fireworks
@@ -133,6 +134,7 @@ enum ModelSelection: String, CaseIterable {
         case .claudeOpus47:    return "Claude Opus 4.7"
         case .claudeSonnet46:  return "Claude Sonnet 4.6"
         case .claudeHaiku45:   return "Claude Haiku 4.5"
+        case .bedrockOpus5:    return "Claude Opus 5"
         case .bedrockOpus48:   return "Claude Opus 4.8"
         case .bedrockOpus47:   return "Claude Opus 4.7"
         case .fireworksKimiK3:  return "Kimi K3"
@@ -155,6 +157,7 @@ enum ModelSelection: String, CaseIterable {
         case .claudeOpus47:    return "claude-opus-4-7"
         case .claudeSonnet46:  return "claude-sonnet-4-6"
         case .claudeHaiku45:   return "claude-haiku-4-5-20251001"
+        case .bedrockOpus5:    return "anthropic.claude-opus-5"
         case .bedrockOpus48:   return "anthropic.claude-opus-4-8"
         case .bedrockOpus47:   return "anthropic.claude-opus-4-7"
         case .fireworksKimiK3:  return "accounts/fireworks/models/kimi-k3-fast"
@@ -186,6 +189,7 @@ enum ModelSelection: String, CaseIterable {
         case .claudeOpus47:     return 200_000
         case .claudeSonnet46:   return 200_000
         case .claudeHaiku45:    return 200_000
+        case .bedrockOpus5:     return 1_048_576
         case .bedrockOpus48:    return 1_048_576
         case .bedrockOpus47:    return 1_048_576
         case .fireworksKimiK3:  return 1_048_576
@@ -233,7 +237,7 @@ enum ModelSelection: String, CaseIterable {
             return true
         case .claudeOpus47, .claudeSonnet46, .claudeHaiku45:
             return true
-        case .bedrockOpus48, .bedrockOpus47:
+        case .bedrockOpus5, .bedrockOpus48, .bedrockOpus47:
             return true
         case .fireworksKimiK3, .fireworksKimiK26:
             return true

--- a/LoopIOS/Data/ModelSelection.swift
+++ b/LoopIOS/Data/ModelSelection.swift
@@ -5,13 +5,14 @@
 //  User-facing choice of which language model handles the next turn.
 //  Persisted in iCloud-KVS-backed UserDefaults so the pick survives
 //  relaunches and syncs across devices. Mac surfaces it as a grouped menu
-//  (Apple / OpenAI ▸ / Anthropic ▸); iOS reads the same store.
+//  (Apple / OpenAI ▸ / Anthropic ▸ / Amazon Bedrock ▸); iOS reads the same store.
 //
 //  AgentHarness reads `ModelSelectionStore.current` at dispatch time and
 //  routes by `.provider`:
 //    .apple     → on-device Apple Foundation model (FoundationModels)
 //    .openAI    → OpenAIChat   (direct, user's OPENAI_API_KEY)
 //    .anthropic → AnthropicChat (direct, user's ANTHROPIC_API_KEY)
+//    .bedrock   → BedrockChat   (direct, user's AWS_BEARER_TOKEN_BEDROCK)
 //    .fireworks → FireworksChat  (direct, user's FIREWORKS_API_KEY)
 //  Reachability still wins — offline always falls back to Apple, since the
 //  hosted providers can't work without a network. The selection is just the
@@ -46,6 +47,7 @@ enum ModelProvider: String, CaseIterable {
     static var firstKeyedProvider: ModelProvider? {
         let ranked: [(ModelProvider, KeyStore.Key)] = [
             (.anthropic, .anthropic),
+            (.bedrock, .bedrock),
             (.openAI, .openAI),
             (.fireworks, .fireworks),
         ]
@@ -65,6 +67,7 @@ enum ModelProvider: String, CaseIterable {
     case apple
     case openAI
     case anthropic
+    case bedrock
     case fireworks
 
     var displayName: String {
@@ -72,6 +75,7 @@ enum ModelProvider: String, CaseIterable {
         case .apple:     return "Apple"
         case .openAI:    return "OpenAI"
         case .anthropic: return "Anthropic"
+        case .bedrock:   return "Amazon Bedrock"
         case .fireworks: return "Fireworks"
         }
     }
@@ -94,6 +98,10 @@ enum ModelSelection: String, CaseIterable {
     case claudeSonnet46 = "claudeSonnet46"
     case claudeHaiku45  = "claudeHaiku45"
 
+    // Amazon Bedrock Mantle — Claude via the user's Bedrock API key.
+    case bedrockOpus48 = "bedrockOpus48"
+    case bedrockOpus47 = "bedrockOpus47"
+
     // Fireworks — models served via Fireworks inference.
     case fireworksKimiK3  = "fireworksKimiK3"
     case fireworksKimiK26 = "fireworksKimiK26"
@@ -107,6 +115,8 @@ enum ModelSelection: String, CaseIterable {
             return .openAI
         case .claudeOpus47, .claudeSonnet46, .claudeHaiku45:
             return .anthropic
+        case .bedrockOpus48, .bedrockOpus47:
+            return .bedrock
         case .fireworksKimiK3, .fireworksKimiK26, .fireworksGLM52:
             return .fireworks
         }
@@ -123,6 +133,8 @@ enum ModelSelection: String, CaseIterable {
         case .claudeOpus47:    return "Claude Opus 4.7"
         case .claudeSonnet46:  return "Claude Sonnet 4.6"
         case .claudeHaiku45:   return "Claude Haiku 4.5"
+        case .bedrockOpus48:   return "Claude Opus 4.8"
+        case .bedrockOpus47:   return "Claude Opus 4.7"
         case .fireworksKimiK3:  return "Kimi K3"
         case .fireworksKimiK26: return "Kimi K2.6"
         case .fireworksGLM52:  return "GLM 5.2"
@@ -143,7 +155,9 @@ enum ModelSelection: String, CaseIterable {
         case .claudeOpus47:    return "claude-opus-4-7"
         case .claudeSonnet46:  return "claude-sonnet-4-6"
         case .claudeHaiku45:   return "claude-haiku-4-5-20251001"
-        case .fireworksKimiK3:  return "accounts/fireworks/models/kimi-k3"
+        case .bedrockOpus48:   return "anthropic.claude-opus-4-8"
+        case .bedrockOpus47:   return "anthropic.claude-opus-4-7"
+        case .fireworksKimiK3:  return "accounts/fireworks/models/kimi-k3-fast"
         case .fireworksKimiK26: return "accounts/fireworks/models/kimi-k2p6"
         case .fireworksGLM52:  return "accounts/fireworks/models/glm-5p2"
         }
@@ -154,6 +168,7 @@ enum ModelSelection: String, CaseIterable {
     var stampedMessageModel: String {
         switch provider {
         case .apple: return "Apple LLM"
+        case .bedrock: return "\(displayName) via Bedrock"
         default:     return displayName
         }
     }
@@ -171,6 +186,8 @@ enum ModelSelection: String, CaseIterable {
         case .claudeOpus47:     return 200_000
         case .claudeSonnet46:   return 200_000
         case .claudeHaiku45:    return 200_000
+        case .bedrockOpus48:    return 1_048_576
+        case .bedrockOpus47:    return 1_048_576
         case .fireworksKimiK3:  return 1_048_576
         case .fireworksKimiK26: return 131_072
         case .fireworksGLM52:  return 1_048_576
@@ -198,6 +215,7 @@ enum ModelSelection: String, CaseIterable {
         case .apple:     return nil
         case .openAI:    return .openAI
         case .anthropic: return .anthropic
+        case .bedrock:   return .bedrock
         case .fireworks: return .fireworks
         }
     }
@@ -214,6 +232,8 @@ enum ModelSelection: String, CaseIterable {
         case .gpt55, .gpt51, .gpt41, .gpt4o:
             return true
         case .claudeOpus47, .claudeSonnet46, .claudeHaiku45:
+            return true
+        case .bedrockOpus48, .bedrockOpus47:
             return true
         case .fireworksKimiK3, .fireworksKimiK26:
             return true
@@ -241,7 +261,7 @@ enum ModelSelection: String, CaseIterable {
         if let sameProvider = models(for: provider).first(where: { $0.supportsVision && $0.isUsable }) {
             return sameProvider
         }
-        for other in [ModelProvider.anthropic, .openAI, .fireworks] where other != provider {
+        for other in [ModelProvider.anthropic, .bedrock, .openAI, .fireworks] where other != provider {
             if let model = models(for: other).first(where: { $0.supportsVision && $0.isUsable }) {
                 return model
             }

--- a/LoopIOS/Data/VisionSummaryService.swift
+++ b/LoopIOS/Data/VisionSummaryService.swift
@@ -44,6 +44,7 @@ final class VisionSummaryService {
     /// caption. Picked per-provider so the summary bills to a key the user
     /// already has.
     private static let anthropicVisionModel = "claude-haiku-4-5-20251001"
+    private static let bedrockVisionModel = "anthropic.claude-opus-4-7"
     private static let openAIVisionModel = "gpt-4o"
     private static let fireworksVisionModel = "accounts/fireworks/models/kimi-k2p6"
 
@@ -109,6 +110,9 @@ final class VisionSummaryService {
         case .anthropic:
             AnthropicChat.shared.chat(messages: [probe], tools: nil,
                                       modelIDOverride: target.modelID, completion: handle)
+        case .bedrock:
+            BedrockChat.shared.chat(messages: [probe], tools: nil,
+                                    modelIDOverride: target.modelID, completion: handle)
         case .openAI:
             OpenAIChat.shared.chat(messages: [probe], tools: nil,
                                    modelIDOverride: target.modelID, completion: handle)
@@ -157,10 +161,12 @@ final class VisionSummaryService {
     /// caller then falls back to on-device OCR.
     private static func visionTarget() -> VisionTarget? {
         let current = ModelSelectionStore.current.provider
-        for provider in [current, .anthropic, .openAI, .fireworks] {
+        for provider in [current, .anthropic, .bedrock, .openAI, .fireworks] {
             switch provider {
             case .anthropic where KeyStore.shared.source(for: .anthropic) != .missing:
                 return VisionTarget(provider: .anthropic, modelID: anthropicVisionModel)
+            case .bedrock where KeyStore.shared.source(for: .bedrock) != .missing:
+                return VisionTarget(provider: .bedrock, modelID: bedrockVisionModel)
             case .openAI where KeyStore.shared.source(for: .openAI) != .missing:
                 return VisionTarget(provider: .openAI, modelID: openAIVisionModel)
             case .fireworks where KeyStore.shared.source(for: .fireworks) != .missing:

--- a/LoopIOS/Info.plist
+++ b/LoopIOS/Info.plist
@@ -33,6 +33,10 @@
 	<string>$(OPENAI_API_KEY)</string>
 	<key>ANTHROPIC_API_KEY</key>
 	<string>$(ANTHROPIC_API_KEY)</string>
+	<key>AWS_BEARER_TOKEN_BEDROCK</key>
+	<string>$(AWS_BEARER_TOKEN_BEDROCK)</string>
+	<key>BEDROCK_AWS_REGION</key>
+	<string>$(BEDROCK_AWS_REGION)</string>
 	<key>FIREWORKS_API_KEY</key>
 	<string>$(FIREWORKS_API_KEY)</string>
 	<key>CURSOR_API_KEY</key>

--- a/LoopIOS/Onboarding/OnboardingCoordinator.swift
+++ b/LoopIOS/Onboarding/OnboardingCoordinator.swift
@@ -917,7 +917,7 @@ final class OnboardingCoordinator {
         let selection: ModelSelection?
         switch key {
         case .anthropic: selection = .claudeSonnet46
-        case .bedrock:   selection = .bedrockOpus48
+        case .bedrock:   selection = .bedrockOpus5
         case .openAI:    selection = .gpt55
         case .fireworks: selection = .fireworksKimiK26
         default:         selection = nil

--- a/LoopIOS/Onboarding/OnboardingCoordinator.swift
+++ b/LoopIOS/Onboarding/OnboardingCoordinator.swift
@@ -125,6 +125,7 @@ final class OnboardingCoordinator {
         static let stayOnCurrent     = "model.stay"
         static let modelApple        = "model.apple"
         static let modelClaude       = "model.claude"
+        static let modelBedrock      = "model.bedrock"
         static let modelOpenAI       = "model.openai"
         static let modelFireworks    = "model.fireworks"
         static let skipKey           = "key.skip"
@@ -279,6 +280,12 @@ final class OnboardingCoordinator {
                 commitAnswer(echo: echo)
                 pinAppleFoundationModel()
                 advance(to: .integrationsOffer)
+            } else if lower.contains("bedrock") || lower.contains("amazon") || lower.contains("aws") {
+                let verb = KeyStore.shared.source(for: .bedrock) != .missing ? "Use" : "Add"
+                commitAnswer(echo: "\(verb) Amazon Bedrock")
+                pendingKeyProvider = .bedrock
+                selectModel(for: .bedrock)
+                advanceAfterModelPick(.bedrock)
             } else if lower.contains("claude") || lower.contains("anthropic") {
                 let verb = KeyStore.shared.source(for: .anthropic) != .missing ? "Use" : "Add"
                 commitAnswer(echo: "\(verb) Claude")
@@ -471,6 +478,13 @@ final class OnboardingCoordinator {
             pendingKeyProvider = .openAI
             selectModel(for: .openAI)
             advanceAfterModelPick(.openAI)
+
+        case (.greeting, ChipId.modelBedrock),
+             (.modelChoice, ChipId.modelBedrock):
+            commitAnswer(echo: label)
+            pendingKeyProvider = .bedrock
+            selectModel(for: .bedrock)
+            advanceAfterModelPick(.bedrock)
 
         case (.greeting, ChipId.modelFireworks),
              (.modelChoice, ChipId.modelFireworks):
@@ -666,6 +680,8 @@ final class OnboardingCoordinator {
                 ? "Use Claude" : "Add Claude"
             let openAILabel = KeyStore.shared.source(for: .openAI) != .missing
                 ? "Use OpenAI" : "Add OpenAI"
+            let bedrockLabel = KeyStore.shared.source(for: .bedrock) != .missing
+                ? "Use Bedrock" : "Add Bedrock"
             let fireworksLabel = KeyStore.shared.source(for: .fireworks) != .missing
                 ? "Use Fireworks" : "Add Fireworks"
             let greetingText: String
@@ -690,6 +706,9 @@ final class OnboardingCoordinator {
             }
             if currentProvider != .openAI {
                 chips.append(.init(id: ChipId.modelOpenAI, label: openAILabel))
+            }
+            if currentProvider != .bedrock {
+                chips.append(.init(id: ChipId.modelBedrock, label: bedrockLabel))
             }
             if currentProvider != .fireworks {
                 chips.append(.init(id: ChipId.modelFireworks, label: fireworksLabel))
@@ -891,13 +910,14 @@ final class OnboardingCoordinator {
 
     /// Set the flagship model for the given provider as the active selection
     /// so the next message routes through it. Called when the user picks a
-    /// provider chip (Claude/OpenAI/Fireworks) AND again when they actually
+    /// provider chip (Claude/OpenAI/Bedrock/Fireworks) AND again when they actually
     /// paste a key — both writes are idempotent. Mirrors what ModelPickerVC
     /// does.
     private func selectModel(for key: KeyStore.Key) {
         let selection: ModelSelection?
         switch key {
         case .anthropic: selection = .claudeSonnet46
+        case .bedrock:   selection = .bedrockOpus48
         case .openAI:    selection = .gpt55
         case .fireworks: selection = .fireworksKimiK26
         default:         selection = nil

--- a/LoopIOS/Runner/VMAgentRuntime.swift
+++ b/LoopIOS/Runner/VMAgentRuntime.swift
@@ -39,12 +39,14 @@ enum VMAgentRuntime {
         let sel = ModelSelectionStore.current
         switch sel.provider {
         case .anthropic: if let k = key(.anthropic), let m = sel.apiModelID { return ("anthropic", m, k, sel.displayName) }
+        case .bedrock:   if let k = key(.bedrock),   let m = sel.apiModelID { return ("bedrock", m, k, sel.displayName) }
         case .openAI:    if let k = key(.openAI),    let m = sel.apiModelID { return ("openai", m, k, sel.displayName) }
         case .fireworks: if let k = key(.fireworks), let m = sel.apiModelID { return ("fireworks", m, k, sel.displayName) }
         case .apple: break
         }
         if let k = key(.openAI)    { return ("openai", "gpt-4o", k, "GPT-4o") }
         if let k = key(.anthropic) { return ("anthropic", "claude-sonnet-4-6", k, "Claude Sonnet 4.6") }
+        if let k = key(.bedrock)   { return ("bedrock", "anthropic.claude-opus-4-7", k, "Claude Opus 4.7") }
         if let k = key(.fireworks) { return ("fireworks", "accounts/fireworks/models/kimi-k2p6", k, "Kimi K2.6") }
         return nil
     }
@@ -179,11 +181,11 @@ def run_openai(base, key, model, msgs):
                          "content": run_tool(c["function"]["name"], a)})
     return "(stopped after %d tool steps)" % MAX_STEPS
 
-def run_anthropic(key, model, system, msgs):
+def run_anthropic(key, model, system, msgs, base="https://api.anthropic.com/v1/messages"):
     headers = {"x-api-key": key, "anthropic-version": "2023-06-01", "content-type": "application/json"}
     tools = tools_anthropic(); system = (system or "") + note()
     for _ in range(MAX_STEPS):
-        resp = http("https://api.anthropic.com/v1/messages", headers,
+        resp = http(base, headers,
                     {"model": model, "max_tokens": 1024, "system": system,
                      "messages": msgs, "tools": tools})
         content = resp.get("content", [])
@@ -205,6 +207,15 @@ try:
         system = "\n\n".join(m.get("content", "") for m in msgs if m.get("role") == "system")
         conv = [m for m in msgs if m.get("role") != "system"]
         text = run_anthropic(key, model, system, conv)
+    elif provider == "bedrock":
+        system = "\n\n".join(m.get("content", "") for m in msgs if m.get("role") == "system")
+        conv = [m for m in msgs if m.get("role") != "system"]
+        region = (ENV.get("BEDROCK_AWS_REGION") or "us-east-1").strip().lower()
+        if (not region or len(region) > 32 or region.startswith("-") or region.endswith("-")
+                or any(not (c.islower() or c.isdigit() or c == "-") for c in region)):
+            region = "us-east-1"
+        base = "https://bedrock-mantle.%s.api.aws/anthropic/v1/messages" % region
+        text = run_anthropic(key, model, system, conv, base)
     else:
         base = ("https://api.fireworks.ai/inference/v1/chat/completions"
                 if provider == "fireworks"

--- a/LoopIOS/Settings/KeyEditVC.swift
+++ b/LoopIOS/Settings/KeyEditVC.swift
@@ -352,7 +352,7 @@ private final class KeyInputRow: UIView, UITextFieldDelegate {
     /// else is a credential that should be entered into a secure field.
     private static func isSecret(_ key: KeyStore.Key) -> Bool {
         switch key {
-        case .obsidianBaseURL, .obsidianVaultName, .githubBaseURL, .devinOrgID:
+        case .obsidianBaseURL, .obsidianVaultName, .githubBaseURL, .devinOrgID, .bedrockRegion:
             return false
         default:
             return true

--- a/LoopIOS/Settings/KeyStore.swift
+++ b/LoopIOS/Settings/KeyStore.swift
@@ -28,6 +28,8 @@ final class KeyStore {
         case exa            = "EXA_API_KEY"
         case openAI         = "OPENAI_API_KEY"
         case anthropic      = "ANTHROPIC_API_KEY"
+        case bedrock        = "AWS_BEARER_TOKEN_BEDROCK"
+        case bedrockRegion  = "BEDROCK_AWS_REGION"
         case fireworks      = "FIREWORKS_API_KEY"
         case cursor         = "CURSOR_API_KEY"
         case obsidianAPI    = "OBSIDIAN_API_KEY"
@@ -60,6 +62,8 @@ final class KeyStore {
             case .exa:                    return "Exa"
             case .openAI:                 return "OpenAI"
             case .anthropic:              return "Anthropic"
+            case .bedrock:                return "Amazon Bedrock API Key"
+            case .bedrockRegion:          return "AWS Region"
             case .fireworks:              return "Fireworks"
             case .cursor:                 return "Cursor"
             case .obsidianAPI:            return "Obsidian API Key"
@@ -94,6 +98,8 @@ final class KeyStore {
             case .exa:                    return "Web search + answer skill"
             case .openAI:                 return "Image generation + OpenAI TTS, and GPT models for the agent"
             case .anthropic:              return "Claude models for the agent"
+            case .bedrock:                return "Claude Opus models through Amazon Bedrock"
+            case .bedrockRegion:          return "Optional Bedrock Mantle region · defaults to us-east-1"
             case .fireworks:              return "Fireworks inference platform (Kimi K2.6, etc.)"
             case .cursor:                 return "Cursor agent integration"
             case .obsidianAPI:            return "Bearer token for the Obsidian relay"
@@ -127,7 +133,7 @@ final class KeyStore {
     /// second). Adding a new key means: (a) add the `Key` case above, (b)
     /// either add a new `Service` case here or extend an existing one's `keys`.
     enum Service: String, CaseIterable {
-        case openAI, anthropic, fireworks, deepgram, elevenLabs, exa
+        case openAI, anthropic, bedrock, fireworks, deepgram, elevenLabs, exa
         case cursor, devin
         case github, slack, notion, obsidian
         case twitter
@@ -141,6 +147,7 @@ final class KeyStore {
             switch self {
             case .openAI:     return "OpenAI"
             case .anthropic:  return "Anthropic"
+            case .bedrock:    return "Amazon Bedrock"
             case .fireworks:  return "Fireworks"
             case .deepgram:   return "Deepgram"
             case .elevenLabs: return "ElevenLabs"
@@ -167,6 +174,7 @@ final class KeyStore {
             switch self {
             case .openAI:     return "Image generation, OpenAI TTS, and GPT models for the agent"
             case .anthropic:  return "Claude models for the agent"
+            case .bedrock:    return "Claude Opus models via Bedrock Mantle using your Amazon Bedrock API key"
             case .fireworks:  return "Fireworks inference platform — run Kimi K2.6 and other open models via Fireworks"
             case .deepgram:   return "Streaming STT + Aura TTS"
             case .elevenLabs: return "Expressive TTS voices"
@@ -194,6 +202,7 @@ final class KeyStore {
             switch self {
             case .openAI:     return [.openAI]
             case .anthropic:  return [.anthropic]
+            case .bedrock:    return [.bedrock, .bedrockRegion]
             case .fireworks:  return [.fireworks]
             case .deepgram:   return [.deepgram]
             case .elevenLabs: return [.elevenLabs]
@@ -330,7 +339,7 @@ final class KeyStore {
         // hide and the URL is the whole point. Same for the Devin org id,
         // which is a `org-…` identifier (not a secret) the user needs to be
         // able to read back when verifying their setup.
-        if key == .obsidianBaseURL || key == .obsidianVaultName || key == .githubBaseURL || key == .devinOrgID || key == .agentMailInbox {
+        if key == .obsidianBaseURL || key == .obsidianVaultName || key == .githubBaseURL || key == .devinOrgID || key == .agentMailInbox || key == .bedrockRegion {
             return raw
         }
         let suffixLen = 4

--- a/LoopIOS/Settings/ModelPickerVC.swift
+++ b/LoopIOS/Settings/ModelPickerVC.swift
@@ -116,6 +116,10 @@ final class ModelPickerVC: UIViewController {
             return keyConfigured(.anthropic)
                 ? "Uses your Anthropic API key."
                 : "Needs an Anthropic API key. Add one in Settings ▸ Keys."
+        case .bedrock:
+            return keyConfigured(.bedrock)
+                ? "Uses your Amazon Bedrock API key. Region defaults to us-east-1."
+                : "Needs an Amazon Bedrock API key. Add one in Settings ▸ Keys."
         case .fireworks:
             return keyConfigured(.fireworks)
                 ? "Uses your Fireworks API key."

--- a/LoopIOS/Skills/Integrations/IntegrationSkill.swift
+++ b/LoopIOS/Skills/Integrations/IntegrationSkill.swift
@@ -491,6 +491,8 @@ Tips:
         case .exa:                    return "exa"
         case .openAI:                 return "openai"
         case .anthropic:              return "anthropic"
+        case .bedrock:                return "bedrock"
+        case .bedrockRegion:          return "bedrock_region"
         case .fireworks:              return "fireworks"
         case .cursor:                 return "cursor"
         case .obsidianAPI:            return "obsidian_api"
@@ -555,6 +557,8 @@ Tips:
         switch n {
         case "openai", "open_ai", "open ai":                  return .openAI
         case "anthropic", "claude":                           return .anthropic
+        case "bedrock", "amazon_bedrock", "amazon bedrock": return .bedrock
+        case "bedrock_region", "bedrock region", "aws_region": return .bedrockRegion
         case "fireworks":                                     return .fireworks
         case "deepgram":                                      return .deepgram
         case "elevenlabs", "eleven_labs", "eleven labs":      return .elevenLabs

--- a/LoopIOSTests/BedrockChatTests.swift
+++ b/LoopIOSTests/BedrockChatTests.swift
@@ -1,0 +1,70 @@
+//
+//  BedrockChatTests.swift
+//  LoopIOSTests
+//
+
+import XCTest
+@testable import Loop
+
+final class BedrockChatTests: XCTestCase {
+
+    func testRegionNormalizationAndEndpoint() {
+        XCTAssertEqual(BedrockChat.normalizedRegion(" US-WEST-2 "), "us-west-2")
+        XCTAssertNil(BedrockChat.normalizedRegion("us-east-1.example.com"))
+        XCTAssertNil(BedrockChat.normalizedRegion("-us-east-1"))
+        XCTAssertEqual(
+            BedrockChat.endpoint(for: "us-east-1")?.absoluteString,
+            "https://bedrock-mantle.us-east-1.api.aws/anthropic/v1/messages")
+    }
+
+    func testRequestBodyUsesAnthropicMessagesAndToolsShape() throws {
+        let messages = [
+            MessageStruct(role: "system", content: "Be concise."),
+            MessageStruct(role: "user", content: "Check the weather."),
+        ]
+        let tools: [[String: Any]] = [[
+            "type": "function",
+            "function": [
+                "name": "weather",
+                "description": "Get weather",
+                "parameters": [
+                    "type": "object",
+                    "properties": ["city": ["type": "string"]],
+                ] as [String: Any],
+            ] as [String: Any],
+        ]]
+
+        let body = BedrockChat.requestBody(
+            messages: messages,
+            tools: tools,
+            modelID: "anthropic.claude-opus-4-8")
+
+        XCTAssertEqual(body["model"] as? String, "anthropic.claude-opus-4-8")
+        XCTAssertEqual(body["system"] as? String, "Be concise.")
+        XCTAssertEqual(body["stream"] as? Bool, true)
+
+        let wireMessages = try XCTUnwrap(body["messages"] as? [[String: Any]])
+        XCTAssertEqual(wireMessages.first?["role"] as? String, "user")
+        let bedrockTools = try XCTUnwrap(body["tools"] as? [[String: Any]])
+        XCTAssertEqual(bedrockTools.first?["name"] as? String, "weather")
+        XCTAssertNotNil(bedrockTools.first?["input_schema"])
+    }
+
+    func testOpusModelsUseBedrockKeyAndOfficialModelIDs() {
+        let expected: [(ModelSelection, String)] = [
+            (.bedrockOpus48, "anthropic.claude-opus-4-8"),
+            (.bedrockOpus47, "anthropic.claude-opus-4-7"),
+        ]
+
+        for (model, modelID) in expected {
+            XCTAssertEqual(model.provider, .bedrock)
+            XCTAssertEqual(model.requiredKey, .bedrock)
+            XCTAssertEqual(model.apiModelID, modelID)
+            XCTAssertTrue(model.supportsVision)
+            XCTAssertEqual(model.contextWindowSize, 1_048_576)
+            XCTAssertTrue(model.stampedMessageModel.hasSuffix("via Bedrock"))
+            XCTAssertEqual(ModelSelection.contextWindowSize(forStamp: model.stampedMessageModel),
+                           1_048_576)
+        }
+    }
+}

--- a/LoopIOSTests/BedrockChatTests.swift
+++ b/LoopIOSTests/BedrockChatTests.swift
@@ -52,6 +52,7 @@ final class BedrockChatTests: XCTestCase {
 
     func testOpusModelsUseBedrockKeyAndOfficialModelIDs() {
         let expected: [(ModelSelection, String)] = [
+            (.bedrockOpus5, "anthropic.claude-opus-5"),
             (.bedrockOpus48, "anthropic.claude-opus-4-8"),
             (.bedrockOpus47, "anthropic.claude-opus-4-7"),
         ]

--- a/LoopMac/Info.plist
+++ b/LoopMac/Info.plist
@@ -53,6 +53,10 @@
 	<string>$(OPENAI_API_KEY)</string>
 	<key>ANTHROPIC_API_KEY</key>
 	<string>$(ANTHROPIC_API_KEY)</string>
+	<key>AWS_BEARER_TOKEN_BEDROCK</key>
+	<string>$(AWS_BEARER_TOKEN_BEDROCK)</string>
+	<key>BEDROCK_AWS_REGION</key>
+	<string>$(BEDROCK_AWS_REGION)</string>
 	<key>FIREWORKS_API_KEY</key>
 	<string>$(FIREWORKS_API_KEY)</string>
 	<key>OBSIDIAN_API_KEY</key>

--- a/LoopMac/LoopMacApp.swift
+++ b/LoopMac/LoopMacApp.swift
@@ -929,4 +929,3 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         }
     }
 }
-

--- a/LoopMac/SettingsWindowController.swift
+++ b/LoopMac/SettingsWindowController.swift
@@ -510,7 +510,7 @@ private final class MacKeyInputRow: NSView {
     /// they're typing. Everything else stays in a secure field.
     private static func isSecret(_ key: KeyStore.Key) -> Bool {
         switch key {
-        case .obsidianBaseURL, .obsidianVaultName, .githubBaseURL, .devinOrgID:
+        case .obsidianBaseURL, .obsidianVaultName, .githubBaseURL, .devinOrgID, .bedrockRegion:
             return false
         default:
             return true

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -20,7 +20,7 @@ flowchart LR
 
     Workspace["Workspace<br/>SOUL, USER, MEMORY,<br/>AGENTS, tools, files"] --> Harness
     Keys["Keychain<br/>user-owned API keys"] --> Providers
-    Harness --> Providers["Model provider<br/>OpenAI, Anthropic, Fireworks,<br/>or Apple on-device"]
+    Harness --> Providers["Model provider<br/>OpenAI, Anthropic, Amazon Bedrock,<br/>Fireworks, or Apple on-device"]
 
     Providers -->|"final text"| Surface
     Providers -->|"tool calls"| Dispatcher["SkillDispatcher"]


### PR DESCRIPTION
## Summary

- add Amazon Bedrock Mantle as a first-class model provider with Claude Opus 5, Opus 4.8, and Opus 4.7 options
- route chat, title generation, vision summaries, portable runner inference, onboarding, model selection, settings, and integration configuration through the Bedrock provider
- store the Bedrock API key and optional AWS region through the existing key-management flow, validating the region before constructing the AWS-owned endpoint
- reuse the Anthropic Messages/tool schema and streaming parser for Bedrock's native Anthropic endpoint
- update Fireworks Kimi K3 to the `accounts/fireworks/models/kimi-k3-fast` model identifier
- add focused Bedrock request-shape, endpoint, and model-metadata tests plus contributor documentation updates

## Why

Loop users can already bring their own provider credentials, but Amazon Bedrock was not available as a selectable inference route. This adds end-to-end Bedrock support while preserving the existing model-selection, fallback, vision, and remote-runner behavior.

## Security

- no credential values are committed
- the Bedrock key uses the existing secure key store and build-setting injection path
- custom regions are normalized to a hostname-safe AWS region token so a stored value cannot redirect the API key to another domain
- the staged patches passed redacted Gitleaks scans

## Validation

- `git diff --cached --check`
- iOS Simulator build: `xcodebuild -project Loop.xcodeproj -scheme Loop_iOS -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`
- `plutil -lint LoopIOS/Info.plist LoopMac/Info.plist`
- `swiftc -frontend -parse LoopIOSTests/BedrockChatTests.swift`
- Gitleaks scans of both staged patches: no leaks found
- confirmed the Claude Opus 5 Bedrock Mantle identifier `anthropic.claude-opus-5` against the official AWS launch documentation

The new `BedrockChatTests` are included, but the repository's `Loop_iOS` scheme is not currently configured with a test action, so `xcodebuild -only-testing` cannot execute them until that scheme configuration is added.
