### PR TITLE
Stream assistant responses in Mac conversations

### DIFF
--- a/LoopMac/ConversationTabBar.swift
+++ b/LoopMac/ConversationTabBar.swift
@@ -34,6 +34,11 @@ final class ConversationTab {
     /// restores its own thinking state instead of whatever was last visible.
     var isThinking: Bool = false
     var thinkingLabel: String?
+    /// Transient provider output for an in-flight turn. This lives on the tab
+    /// (not the window) so switching away and back can restore the partial
+    /// response while background tabs continue streaming independently.
+    var streamingAssistantText: String = ""
+    var streamingAssistantModel: String?
 
     init(conversation: SimpleConversation, coordinator: VoiceLoopCoordinator) {
         self.conversation = conversation

--- a/LoopMac/ConversationWindowController.swift
+++ b/LoopMac/ConversationWindowController.swift
@@ -45,6 +45,11 @@ final class ConversationWindowController: NSWindowController, ConversationPresen
     private let stack = NSStackView()
     private let thinkingLabel = NSTextField(labelWithString: "")
     private let avatarView = AvatarView()
+    /// The one transient assistant row for the active tab. Provider deltas
+    /// mutate its text view in place; the completed persisted message replaces
+    /// it when the request finishes.
+    private weak var streamingAssistantRow: NSView?
+    private weak var streamingAssistantTextView: ChatLinkTextView?
     /// Tappable "N sub-agents running" pill that sits between the avatar and
     /// the scroll view. Hides itself when no agents are alive.
     private let subAgentStatusBar = SubAgentMacStatusBar()
@@ -890,6 +895,8 @@ final class ConversationWindowController: NSWindowController, ConversationPresen
 
     private func rebuild(messages: [SimpleMessage]) {
         for view in stack.arrangedSubviews { stack.removeArrangedSubview(view); view.removeFromSuperview() }
+        streamingAssistantRow = nil
+        streamingAssistantTextView = nil
         // Forget the bubble views — they're being torn down. The attachment
         // map survives so we can re-render their state below.
         imageBubbles.removeAll()
@@ -1007,7 +1014,8 @@ final class ConversationWindowController: NSWindowController, ConversationPresen
                     } else if let gallery = m.imageGalleryAttachment {
                         stack.addArrangedSubview(makeImageGalleryRow(bubbleView: ImageGalleryBubbleView(attachment: gallery)))
                     } else {
-                        stack.addArrangedSubview(makeBubble(role: message.role, text: message.content, model: m.role == "assistant" ? m.model : nil))
+                        let caption = m.role == "assistant" ? modelText(for: m) : nil
+                        stack.addArrangedSubview(makeBubble(role: message.role, text: message.content, model: caption))
                     }
                 }
 
@@ -1029,6 +1037,14 @@ final class ConversationWindowController: NSWindowController, ConversationPresen
             default:
                 continue
             }
+        }
+        // A store refresh or tab activation rebuilds only persisted messages.
+        // Restore this tab's in-flight partial immediately afterwards so it
+        // does not disappear while the provider is still streaming.
+        if let tab = activeTab,
+           !tab.streamingAssistantText.isEmpty {
+            renderStreamingAssistant(tab.streamingAssistantText,
+                                     model: tab.streamingAssistantModel ?? ModelSelectionStore.current.stampedMessageModel)
         }
         scrollToBottom()
     }
@@ -1190,12 +1206,34 @@ final class ConversationWindowController: NSWindowController, ConversationPresen
         scrollToBottom()
     }
 
+    func appendAssistantMessage(_ message: MessageStruct) {
+        clearStreamingAssistant()
+        appendAssistantMessage(message.content, model: modelText(for: message))
+    }
+
+    /// Text/model overload retained for scripted onboarding bubbles, which do
+    /// not carry provider metrics and intentionally omit the model caption.
     func appendAssistantMessage(_ text: String, model: String?) {
         stack.addArrangedSubview(makeBubble(role: "assistant", text: text, model: model))
         scrollToBottom()
         // Speaking starts immediately after the assistant text lands, so
         // this is the right moment to make sure the window is on screen.
         surfaceForResponse()
+    }
+
+    func appendAssistantDelta(_ delta: String, model: String) {
+        guard !delta.isEmpty else { return }
+        let accumulated = (streamingAssistantTextView?.string ?? "") + delta
+        renderStreamingAssistant(accumulated, model: model)
+    }
+
+    func clearStreamingAssistant() {
+        if let row = streamingAssistantRow {
+            stack.removeArrangedSubview(row)
+            row.removeFromSuperview()
+        }
+        streamingAssistantRow = nil
+        streamingAssistantTextView = nil
     }
 
     func setThinking(_ thinking: Bool, label: String?) {
@@ -1235,7 +1273,10 @@ final class ConversationWindowController: NSWindowController, ConversationPresen
         avatarView.pulse()
     }
 
-    private func makeBubble(role: String, text: String, model: String?) -> NSView {
+    private func makeBubble(role: String,
+                            text: String,
+                            model: String?,
+                            captureAssistantTextView: ((ChatLinkTextView) -> Void)? = nil) -> NSView {
         let isUser = role == "user"
         // AdaptiveBubbleView for user turns so the systemBlue fill
         // re-resolves on appearance change; assistant turns stay a plain
@@ -1265,12 +1306,14 @@ final class ConversationWindowController: NSWindowController, ConversationPresen
             label.textColor = .white
             label.stringValue = text
             contentView = label
-        } else if MarkdownSegmenter.containsRichContent(in: text) {
+        } else if captureAssistantTextView == nil,
+                  MarkdownSegmenter.containsRichContent(in: text) {
             contentView = makeAssistantRichContentView(text: text, maxWidth: 380 - 24)
         } else {
             let tv = ChatLinkTextView.makeBubbleTextView(maxTextWidth: 380 - 24)
             tv.delegate = self
             tv.textStorage?.setAttributedString(Self.markdownAttributedString(from: text))
+            captureAssistantTextView?(tv)
             contentView = tv
         }
         contentView.translatesAutoresizingMaskIntoConstraints = false
@@ -1332,6 +1375,47 @@ final class ConversationWindowController: NSWindowController, ConversationPresen
         }
         bubble.widthAnchor.constraint(lessThanOrEqualToConstant: 380).isActive = true
         return row
+    }
+
+    /// Match the iOS byline: model name, time-to-first-token, then context use
+    /// when the provider returned usage and the selected model has a known
+    /// context window.
+    private func modelText(for message: MessageStruct) -> String {
+        var text = message.model
+        if let ttft = message.ttft {
+            text += String(format: " %.2fs", ttft)
+        }
+        if let usage = message.tokenUsage,
+           let window = ModelSelection.contextWindowSize(forStamp: message.model),
+           let percent = usage.contextPercent(windowSize: window) {
+            text += " | Context \(percent)%"
+        }
+        return text
+    }
+
+    /// Create the transient row on the first delta, then update its text view
+    /// in place. Rich markdown/table segmentation waits until completion so a
+    /// half-written table cannot churn the view hierarchy on every token.
+    private func renderStreamingAssistant(_ text: String, model: String) {
+        guard !text.isEmpty else { return }
+        if let textView = streamingAssistantTextView {
+            textView.textStorage?.setAttributedString(Self.markdownAttributedString(from: text))
+            textView.invalidateIntrinsicContentSize()
+            textView.superview?.invalidateIntrinsicContentSize()
+        } else {
+            var captured: ChatLinkTextView?
+            let row = makeBubble(
+                role: "assistant",
+                text: text,
+                model: model,
+                captureAssistantTextView: { captured = $0 }
+            )
+            streamingAssistantRow = row
+            streamingAssistantTextView = captured
+            stack.addArrangedSubview(row)
+        }
+        scrollToBottom()
+        surfaceForResponse()
     }
 
     /// Render a user-uploaded attachment as a bubble, with any accompanying
@@ -3096,9 +3180,26 @@ final class TabConversationPresenter: ConversationPresenter {
         window?.appendUserAttachment(attachment, text: text)
     }
 
-    func appendAssistantMessage(_ text: String, model: String?) {
+    func appendAssistantMessage(_ message: MessageStruct) {
+        tab?.streamingAssistantText = ""
+        tab?.streamingAssistantModel = nil
         guard isForeground else { return }
-        window?.appendAssistantMessage(text, model: model)
+        window?.appendAssistantMessage(message)
+    }
+
+    func appendAssistantDelta(_ delta: String, model: String) {
+        guard let tab = tab, !delta.isEmpty else { return }
+        tab.streamingAssistantText += delta
+        tab.streamingAssistantModel = model
+        guard isForeground else { return }
+        window?.appendAssistantDelta(delta, model: model)
+    }
+
+    func clearStreamingAssistant() {
+        tab?.streamingAssistantText = ""
+        tab?.streamingAssistantModel = nil
+        guard isForeground else { return }
+        window?.clearStreamingAssistant()
     }
 
     func setThinking(_ thinking: Bool, label: String?) {

--- a/LoopMac/VoiceLoopCoordinator.swift
+++ b/LoopMac/VoiceLoopCoordinator.swift
@@ -38,7 +38,14 @@ protocol ConversationPresenter: AnyObject {
     /// followed by accompanying text underneath. Mirrors `appendUserMessage`'s
     /// fast-path that adds a row without reloading the whole conversation.
     func appendUserAttachment(_ attachment: FileAttachment, text: String?)
-    func appendAssistantMessage(_ text: String, model: String?)
+    /// Append a completed assistant response. Pass the whole message so the
+    /// presenter can render provider timing/usage metadata alongside the model.
+    func appendAssistantMessage(_ message: MessageStruct)
+    /// Add one provider-streamed text delta to the transient assistant bubble.
+    func appendAssistantDelta(_ delta: String, model: String)
+    /// Remove any transient assistant bubble (completion, tool hop, error,
+    /// cancellation, or conversation switch).
+    func clearStreamingAssistant()
     func setThinking(_ thinking: Bool, label: String?)
     /// Forward state transitions so the conversation window's avatar can
     /// reflect what Loop is doing. The presenter handles the mapping
@@ -640,6 +647,7 @@ The current date and time is \(now).
         conversationPresenter?.showAndReload()
         conversationPresenter?.avatarPulse()
         conversationPresenter?.setThinking(true, label: "Thinking…")
+        conversationPresenter?.clearStreamingAssistant()
 
         // Opportunistic context compaction: check thresholds and spawn a
         // background sub-agent if the context is large enough.
@@ -649,7 +657,10 @@ The current date and time is \(now).
         )
 
         state = .thinking
-        Cloud.connection.chat(messages: messages) { [weak self] response, error in
+        Cloud.connection.chat(
+            messages: messages,
+            onPartial: streamingHandler(for: token)
+        ) { [weak self] response, error in
             DispatchQueue.main.async {
                 if compactionTrigger == .hard, var r = response {
                     r.content += "\n\n(compacting context in the background)"
@@ -664,6 +675,7 @@ The current date and time is \(now).
     private func handleChatResponse(_ response: MessageStruct?, error: Error?, token: UUID) {
         guard currentTurnToken == token else { return }
         guard let response = response else {
+            conversationPresenter?.clearStreamingAssistant()
             EarconPlayer.shared.play(.error)
             if let error = error {
                 print("Mac chat error: \(error)")
@@ -687,7 +699,7 @@ The current date and time is \(now).
             msg.model = ModelSelectionStore.current.stampedMessageModel
             persistAssistant(msg)
             conversationPresenter?.setThinking(false, label: nil)
-            conversationPresenter?.appendAssistantMessage(msg.content, model: msg.model)
+            conversationPresenter?.appendAssistantMessage(msg)
             currentTurnToken = nil
             currentTurnUserMessageId = nil
             state = .idle
@@ -703,10 +715,14 @@ The current date and time is \(now).
 
         if message.role == "function" {
             // Tool result coming back from a skill — send to harness.
+            conversationPresenter?.clearStreamingAssistant()
             messages.append(message)
             state = .thinking
             conversationPresenter?.setThinking(true, label: "Thinking…")
-            Cloud.connection.chat(messages: messages) { [weak self] response, error in
+            Cloud.connection.chat(
+                messages: messages,
+                onPartial: streamingHandler(for: token)
+            ) { [weak self] response, error in
                 DispatchQueue.main.async { self?.handleChatResponse(response, error: error, token: token) }
             }
             return
@@ -717,6 +733,7 @@ The current date and time is \(now).
             // once (so the model sees its own call list on the next round-
             // trip), flip the shimmer to the first call's status, then fan
             // out every call concurrently and re-enter chat with all results.
+            conversationPresenter?.clearStreamingAssistant()
             messages.append(message)
             if let first = message.functions.first {
                 conversationPresenter?.setThinking(true, label: statusText(for: first))
@@ -727,14 +744,16 @@ The current date and time is \(now).
 
         // Plain assistant text — turn is complete.
         if !message.content.isEmpty {
+            conversationPresenter?.clearStreamingAssistant()
             persistAssistant(message)
             conversationPresenter?.setThinking(false, label: nil)
-            conversationPresenter?.appendAssistantMessage(message.content, model: message.model)
+            conversationPresenter?.appendAssistantMessage(message)
             conversationPresenter?.avatarPulse()
             currentTurnToken = nil
             currentTurnUserMessageId = nil
             speak(message.content)
         } else {
+            conversationPresenter?.clearStreamingAssistant()
             currentTurnToken = nil
             currentTurnUserMessageId = nil
             state = .idle
@@ -784,7 +803,11 @@ The current date and time is \(now).
         }
         state = .thinking
         conversationPresenter?.setThinking(true, label: "Thinking…")
-        Cloud.connection.chat(messages: messages) { [weak self] response, error in
+        conversationPresenter?.clearStreamingAssistant()
+        Cloud.connection.chat(
+            messages: messages,
+            onPartial: streamingHandler(for: token)
+        ) { [weak self] response, error in
             DispatchQueue.main.async { self?.handleChatResponse(response, error: error, token: token) }
         }
     }
@@ -1006,6 +1029,21 @@ The current date and time is \(now).
         }
     }
 
+    /// Bind provider deltas to the turn token so an escape/cancel or tab
+    /// conversation switch cannot paint stale text after the turn is gone.
+    /// `AgentHarness` invokes this callback on a URLSession delegate queue;
+    /// presenters are AppKit-facing, so hop to main before forwarding.
+    private func streamingHandler(for token: UUID) -> (String) -> Void {
+        let model = ModelSelectionStore.current.stampedMessageModel
+        return { [weak self] delta in
+            guard !delta.isEmpty else { return }
+            DispatchQueue.main.async {
+                guard let self = self, self.currentTurnToken == token else { return }
+                self.conversationPresenter?.appendAssistantDelta(delta, model: model)
+            }
+        }
+    }
+
     // MARK: - TTS
 
     /// Hands off to MacSpeechPlayer, which dispatches to the user's chosen
@@ -1068,6 +1106,7 @@ The current date and time is \(now).
             teardownStreaming()
         case .thinking:
             currentTurnToken = nil
+            conversationPresenter?.clearStreamingAssistant()
             if let userId = currentTurnUserMessageId, let conv = conversation {
                 SimpleConversationManager.shared.removeMessage(id: userId, from: conv)
                 if let refreshed = SimpleConversationManager.shared.getConversation(by: conv.id) {


### PR DESCRIPTION
## Summary

- render provider text deltas in a transient assistant bubble on macOS
- keep in-flight streamed text isolated per conversation tab
- replace the transient row with the persisted completed message
- show TTFT and context usage in completed assistant captions when available

## Why

Mac conversations previously waited for the full provider response before displaying assistant text. Background tab changes could also lose transient response state because streaming output was not owned by the tab.

## User impact

Assistant responses now appear incrementally, remain attached to the correct tab, and expose the same useful timing/context metadata as the completed response path.

## Validation

- git diff --check
- staged Gitleaks scan: no leaks found
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project Loop.xcodeproj -scheme Loop_MacOS -configuration Debug -destination platform=macOS -derivedDataPath /tmp/loopharness-mac-streaming-derived CODE_SIGNING_ALLOWED=NO build