### PR TITLE
Add local Codex agent integration to the Mac app

### DIFF
--- a/LoopIOS/Data/SpeechProvider.swift
+++ b/LoopIOS/Data/SpeechProvider.swift
@@ -133,7 +133,8 @@ enum TTSProvider: String, CaseIterable {
                 ("Rory (irish male)",             "hmMWXCj9K7N5mCPcRkfC"),
                 ("Hannah (american female)",      "ZSNL4hPqCnqoMPaI4jGX"),
                 ("Zoe (african american female)", "M6ic45wruJGWAxLFEMNK"),
-                ("Agent (secret agent male)",     "ICIc5IiEgLitxGwyb7ZG")
+                ("Agent (secret agent male)",     "ICIc5IiEgLitxGwyb7ZG"),
+                ("Friendly Californian",           "c3VtJKuoGvBc0vUNQf8k")
             ]
         case .openAIMiniTTS:
             return ["alloy", "echo", "fable", "onyx", "nova",
@@ -148,8 +149,8 @@ enum TTSProvider: String, CaseIterable {
     var defaultVoiceId: String {
         switch self {
         case .aura2:              return "aura-2-thalia-en"
-        case .elevenLabsV3:       return "21m00Tcm4TlvDq8ikWAM"
-        case .elevenLabsFlashV25: return "ZSNL4hPqCnqoMPaI4jGX" // Hannah (american female)
+        case .elevenLabsV3:       return "c3VtJKuoGvBc0vUNQf8k"
+        case .elevenLabsFlashV25: return "c3VtJKuoGvBc0vUNQf8k"
         case .openAIMiniTTS:      return "shimmer"
         case .system:             return ""
         }

--- a/LoopIOS/MessagingVC.swift
+++ b/LoopIOS/MessagingVC.swift
@@ -3963,9 +3963,9 @@ extension MessagingVC {
 
 extension MessagingVC {
 
-    /// Default ElevenLabs voice. Rachel — clear, warm, common default. Override
+    /// Default ElevenLabs voice. Friendly Californian. Override
     /// by adding ELEVEN_LABS_VOICE_ID to Info.plist.
-    fileprivate static let elevenLabsDefaultVoiceId = "21m00Tcm4TlvDq8ikWAM"
+    fileprivate static let elevenLabsDefaultVoiceId = "c3VtJKuoGvBc0vUNQf8k"
 
     /// Default OpenAI voice. "shimmer" is warm and conversational. Override
     /// via OPENAI_TTS_VOICE in Info.plist (alloy, echo, fable, onyx, nova,

--- a/LoopIOS/Onboarding/OnboardingCoordinator.swift
+++ b/LoopIOS/Onboarding/OnboardingCoordinator.swift
@@ -760,6 +760,7 @@ final class OnboardingCoordinator {
                 // Curated shortlist, in display order. Resolved against the
                 // provider's `voiceOptions` so labels/ids stay in sync.
                 let orderedVoiceIds = [
+                    "c3VtJKuoGvBc0vUNQf8k", // Friendly Californian
                     "ZSNL4hPqCnqoMPaI4jGX", // Hannah
                     "sIivXWc5MTlPIP3kJXhg", // Hayes
                     "M6ic45wruJGWAxLFEMNK", // Zoe

--- a/LoopIOS/SubAgents/SubAgentManager.swift
+++ b/LoopIOS/SubAgents/SubAgentManager.swift
@@ -60,6 +60,14 @@ final class SubAgentManager {
             name: .cursorAgentsDidChange,
             object: nil
         )
+        #if os(macOS)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(remoteJobsDidChange),
+            name: .codexAgentsDidChange,
+            object: nil
+        )
+        #endif
     }
 
     @objc private func remoteJobsDidChange() {
@@ -174,7 +182,14 @@ final class SubAgentManager {
         let cursor = CursorAgentService.shared.allJobs().filter { job in
             !job.isTerminal && matches(conversationId, candidate: job.conversationId)
         }.count
-        return native + devin + cursor
+        #if os(macOS)
+        let codex = CodexAgentService.shared.allJobs().filter { job in
+            !job.isTerminal && matches(conversationId, candidate: job.conversationId)
+        }.count
+        #else
+        let codex = 0
+        #endif
+        return native + devin + cursor + codex
     }
 
     /// True if anything in the union is in an "actively making progress" state
@@ -191,6 +206,11 @@ final class SubAgentManager {
         if CursorAgentService.shared.allJobs().contains(where: { job in
             !job.isTerminal && matches(conversationId, candidate: job.conversationId)
         }) { return true }
+        #if os(macOS)
+        if CodexAgentService.shared.allJobs().contains(where: { job in
+            !job.isTerminal && matches(conversationId, candidate: job.conversationId)
+        }) { return true }
+        #endif
         return false
     }
 
@@ -203,7 +223,14 @@ final class SubAgentManager {
         let cursor = CursorAgentService.shared.allJobs().filter { job in
             !job.isTerminal && matches(conversationId, candidate: job.conversationId)
         }.count
-        return devin + cursor
+        #if os(macOS)
+        let codex = CodexAgentService.shared.allJobs().filter { job in
+            !job.isTerminal && matches(conversationId, candidate: job.conversationId)
+        }.count
+        #else
+        let codex = 0
+        #endif
+        return devin + cursor + codex
     }
 
     /// Conversation scoping rule shared by the aggregate helpers: a nil filter

--- a/LoopMac/Codex/CodexAgentService.swift
+++ b/LoopMac/Codex/CodexAgentService.swift
@@ -1,0 +1,563 @@
+//
+//  CodexAgentService.swift
+//  LoopMac
+//
+//  Project registry and durable job coordinator for local Codex agents. It
+//  translates Loop operations into app-server thread/turn calls, persists
+//  enough state to survive relaunch, and posts a terminal result back into
+//  the conversation that dispatched the work exactly once.
+//
+
+import AppKit
+import Foundation
+import UserNotifications
+
+extension Notification.Name {
+    static let codexAgentsDidChange = Notification.Name("loop.codex.agentsDidChange")
+    static let codexAgentDidPostMessage = Notification.Name("loop.codex.agentDidPostMessage")
+    static let codexProjectsDidChange = Notification.Name("loop.codex.projectsDidChange")
+}
+
+final class CodexAgentService {
+    static let shared = CodexAgentService()
+
+    enum DispatchResult {
+        case success(CodexAgentJob)
+        case failure(String)
+    }
+
+    private let client = CodexAppServerClient.shared
+    private let queue = DispatchQueue(label: "loop.codex.agent-service")
+    private let projectsKey = "loop.codex.projects.v1"
+    private let jobsKey = "loop.codex.jobs.v1"
+    private let maxLogs = 100
+    private var responseTextByJob: [String: String] = [:]
+
+    private init() {
+        client.onNotification = { [weak self] method, params in
+            self?.handleNotification(method: method, params: params)
+        }
+    }
+
+    // MARK: - Availability and account
+
+    func status(completion: @escaping (String) -> Void) {
+        guard CodexAppServerClient.isAvailable else {
+            completion("Codex CLI not found")
+            return
+        }
+        client.request(method: "account/read", params: ["refreshToken": false]) { result in
+            switch result {
+            case .failure(let error): completion(error.localizedDescription)
+            case .success(let payload):
+                if let account = payload["account"] as? [String: Any] {
+                    let email = account["email"] as? String
+                    let type = account["type"] as? String
+                    completion(email ?? type.map { "Connected (\($0))" } ?? "Connected")
+                } else {
+                    completion("Codex CLI installed; sign-in required")
+                }
+            }
+        }
+    }
+
+    // MARK: - Projects
+
+    func projects() -> [CodexProject] {
+        queue.sync { loadProjectsUnlocked().sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending } }
+    }
+
+    @discardableResult
+    func addProject(path: String,
+                    name: String? = nil,
+                    allowWrites: Bool = false) -> Result<CodexProject, Error> {
+        let url = URL(fileURLWithPath: path).resolvingSymlinksInPath().standardizedFileURL
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory), isDirectory.boolValue else {
+            return .failure(CodexAppServerError.unavailable("Project directory does not exist: \(url.path)"))
+        }
+        let home = FileManager.default.homeDirectoryForCurrentUser
+            .resolvingSymlinksInPath().standardizedFileURL.path
+        guard url.path != "/", url.path != home else {
+            return .failure(CodexAppServerError.unavailable(
+                "Choose a specific project directory, not the filesystem root or your entire home directory."
+            ))
+        }
+        var saved = CodexProject(path: url.path,
+                                 name: name,
+                                 defaultAccess: allowWrites ? .workspaceWrite : .readOnly)
+        queue.sync {
+            var all = loadProjectsUnlocked()
+            if let index = all.firstIndex(where: { $0.id == saved.id }) {
+                saved.addedAt = all[index].addedAt
+                saved.lastUsedAt = all[index].lastUsedAt
+                all[index] = saved
+            } else {
+                all.append(saved)
+            }
+            saveProjectsUnlocked(all)
+        }
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(name: .codexProjectsDidChange, object: nil)
+        }
+        return .success(saved)
+    }
+
+    func refreshProjects(completion: @escaping (Result<[CodexProject], Error>) -> Void) {
+        let sourceKinds = ["cli", "vscode", "exec", "appServer", "subAgent", "subAgentReview",
+                           "subAgentCompact", "subAgentThreadSpawn", "subAgentOther", "unknown"]
+        fetchProjectPaths(cursor: nil,
+                          pagesRemaining: 10,
+                          accumulated: [],
+                          sourceKinds: sourceKinds,
+                          completion: completion)
+    }
+
+    private func fetchProjectPaths(cursor: String?,
+                                   pagesRemaining: Int,
+                                   accumulated: Set<String>,
+                                   sourceKinds: [String],
+                                   completion: @escaping (Result<[CodexProject], Error>) -> Void) {
+        var params: [String: Any] = [
+            "limit": 100,
+            "sortKey": "updated_at",
+            "sourceKinds": sourceKinds
+        ]
+        if let cursor { params["cursor"] = cursor }
+        client.request(method: "thread/list", params: params) { result in
+            switch result {
+            case .failure(let error): completion(.failure(error))
+            case .success(let payload):
+                let threads = payload["data"] as? [[String: Any]] ?? []
+                var paths = accumulated
+                paths.formUnion(threads.compactMap {
+                    ($0["cwd"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+                }.filter { !$0.isEmpty })
+                if let next = payload["nextCursor"] as? String,
+                   !next.isEmpty,
+                   pagesRemaining > 1 {
+                    self.fetchProjectPaths(cursor: next,
+                                           pagesRemaining: pagesRemaining - 1,
+                                           accumulated: paths,
+                                           sourceKinds: sourceKinds,
+                                           completion: completion)
+                    return
+                }
+                for path in paths {
+                    _ = self.addProject(path: path)
+                }
+                completion(.success(self.projects()))
+            }
+        }
+    }
+
+    func project(matching identifier: String) -> CodexProject? {
+        let needle = identifier.trimmingCharacters(in: .whitespacesAndNewlines)
+        let standardized = URL(fileURLWithPath: needle)
+            .resolvingSymlinksInPath().standardizedFileURL.path
+        return projects().first {
+            $0.id == needle || $0.path == standardized || $0.name.caseInsensitiveCompare(needle) == .orderedSame
+        }
+    }
+
+    func removeProject(id: String) -> Result<Void, Error> {
+        if allJobs().contains(where: { !$0.isTerminal && $0.projectId == id }) {
+            return .failure(CodexAppServerError.unavailable("Stop the running Codex agent before removing this project."))
+        }
+        var removed = false
+        queue.sync {
+            var all = loadProjectsUnlocked()
+            let before = all.count
+            all.removeAll { $0.id == id }
+            removed = all.count != before
+            if removed { saveProjectsUnlocked(all) }
+        }
+        guard removed else {
+            return .failure(CodexAppServerError.unavailable("Project is no longer registered."))
+        }
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(name: .codexProjectsDidChange, object: nil)
+        }
+        return .success(())
+    }
+
+    // MARK: - Jobs
+
+    func allJobs() -> [CodexAgentJob] {
+        queue.sync { loadJobsUnlocked().sorted { $0.createdAt > $1.createdAt } }
+    }
+
+    func job(id: String) -> CodexAgentJob? {
+        queue.sync { loadJobsUnlocked().first { $0.id == id || $0.threadId == id } }
+    }
+
+    func dispatch(task: String,
+                  project: CodexProject,
+                  access: CodexAccessMode,
+                  conversationId: String,
+                  completion: @escaping (DispatchResult) -> Void) {
+        guard !task.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            completion(.failure("task is required")); return
+        }
+        guard access != .workspaceWrite || project.defaultAccess == .workspaceWrite else {
+            completion(.failure("Write access is not enabled for \(project.name). Add or update the project with allow_writes=true first."))
+            return
+        }
+        if access == .workspaceWrite,
+           allJobs().contains(where: { !$0.isTerminal && $0.projectId == project.id && $0.access == .workspaceWrite }) {
+            completion(.failure("A write-enabled Codex agent is already running in \(project.name). Wait for it to finish or cancel it before starting another."))
+            return
+        }
+
+        let now = Date()
+        var job = CodexAgentJob(
+            id: UUID().uuidString,
+            threadId: nil,
+            turnId: nil,
+            conversationId: conversationId,
+            projectId: project.id,
+            projectPath: project.path,
+            task: task,
+            access: access,
+            state: .queued,
+            currentStep: "Starting Codex",
+            createdAt: now,
+            updatedAt: now,
+            finalResponse: nil,
+            error: nil,
+            postedBack: false,
+            logs: [CodexAgentLogEntry("Queued for \(project.name) (\(access.displayName))")]
+        )
+        upsert(job)
+
+        client.request(method: "thread/start", params: [
+            "cwd": project.path,
+            "approvalPolicy": "never",
+            "sandbox": access.rawValue,
+            "developerInstructions": "This turn is unattended. Do not ask the user questions or request expanded permissions. Use best judgment within the configured sandbox, and explain any blocker in the final response.",
+            "serviceName": "loop_harness"
+        ]) { result in
+            switch result {
+            case .failure(let error):
+                self.fail(jobId: job.id, message: error.localizedDescription)
+                completion(.failure(error.localizedDescription))
+            case .success(let payload):
+                guard let thread = payload["thread"] as? [String: Any],
+                      let threadId = thread["id"] as? String else {
+                    let message = "Codex did not return a thread id."
+                    self.fail(jobId: job.id, message: message)
+                    completion(.failure(message))
+                    return
+                }
+                job.threadId = threadId
+                job.state = .running
+                job.currentStep = "Codex is working"
+                job.updatedAt = Date()
+                job.logs.append(CodexAgentLogEntry("Started thread \(threadId.prefix(12))"))
+                self.upsert(job)
+                self.touchProject(project.id)
+
+                self.client.request(method: "turn/start", params: [
+                    "threadId": threadId,
+                    "input": [["type": "text", "text": task]]
+                ]) { turnResult in
+                    switch turnResult {
+                    case .failure(let error):
+                        self.fail(jobId: job.id, message: error.localizedDescription)
+                    case .success(let turnPayload):
+                        if let turn = turnPayload["turn"] as? [String: Any],
+                           let turnId = turn["id"] as? String {
+                            self.mutate(jobId: job.id) {
+                                $0.turnId = turnId
+                                $0.currentStep = "Turn in progress"
+                                $0.logs.append(CodexAgentLogEntry("Turn \(turnId.prefix(12)) started"))
+                            }
+                        }
+                    }
+                }
+                completion(.success(job))
+            }
+        }
+    }
+
+    func continueAgent(id: String,
+                       instruction: String,
+                       completion: @escaping (Result<CodexAgentJob, Error>) -> Void) {
+        guard let original = job(id: id), let threadId = original.threadId else {
+            completion(.failure(CodexAppServerError.unavailable("No tracked Codex agent with id \(id).")))
+            return
+        }
+        guard original.isTerminal else {
+            completion(.failure(CodexAppServerError.unavailable("That Codex agent is still running. Use cancel before replacing its active turn.")))
+            return
+        }
+        client.request(method: "thread/resume", params: ["threadId": threadId]) { result in
+            switch result {
+            case .failure(let error): completion(.failure(error))
+            case .success:
+                self.mutate(jobId: original.id) {
+                    $0.state = .running
+                    $0.currentStep = "Continuing Codex thread"
+                    $0.finalResponse = nil
+                    $0.error = nil
+                    $0.postedBack = false
+                    $0.logs.append(CodexAgentLogEntry("Follow-up: \(instruction)"))
+                }
+                self.responseTextByJob[original.id] = ""
+                self.client.request(method: "turn/start", params: [
+                    "threadId": threadId,
+                    "input": [["type": "text", "text": instruction]]
+                ]) { turnResult in
+                    switch turnResult {
+                    case .failure(let error):
+                        self.fail(jobId: original.id, message: error.localizedDescription)
+                        completion(.failure(error))
+                    case .success(let payload):
+                        self.mutate(jobId: original.id) {
+                            $0.turnId = (payload["turn"] as? [String: Any])?["id"] as? String
+                            $0.currentStep = "Turn in progress"
+                        }
+                        completion(.success(self.job(id: original.id) ?? original))
+                    }
+                }
+            }
+        }
+    }
+
+    func cancel(id: String, completion: @escaping (Result<CodexAgentJob, Error>) -> Void) {
+        guard let current = job(id: id),
+              let threadId = current.threadId,
+              let turnId = current.turnId else {
+            completion(.failure(CodexAppServerError.unavailable("No active Codex turn found for \(id).")))
+            return
+        }
+        client.request(method: "turn/interrupt", params: ["threadId": threadId, "turnId": turnId]) { result in
+            switch result {
+            case .failure(let error): completion(.failure(error))
+            case .success:
+                self.finish(jobId: current.id, state: .cancelled, error: nil)
+                completion(.success(self.job(id: current.id) ?? current))
+            }
+        }
+    }
+
+    /// Relaunch recovery cannot re-subscribe to an in-flight turn reliably
+    /// without resuming it, so mark interrupted local children explicitly.
+    /// Stored completed jobs remain available in the inspector.
+    func resumePending() {
+        for job in allJobs() where !job.isTerminal {
+            fail(jobId: job.id, message: "Loop quit while this local Codex agent was running. Continue it to start a new turn on the same Codex thread.")
+        }
+    }
+
+    // MARK: - Notifications
+
+    private func handleNotification(method: String, params: [String: Any]) {
+        guard let threadId = params["threadId"] as? String,
+              let current = allJobs().first(where: { $0.threadId == threadId }) else { return }
+
+        switch method {
+        case "item/agentMessage/delta":
+            let delta = params["delta"] as? String ?? ""
+            responseTextByJob[current.id, default: ""].append(delta)
+        case "item/started":
+            guard let item = params["item"] as? [String: Any] else { return }
+            let type = (item["type"] as? String ?? "item").replacingOccurrences(of: "_", with: " ")
+            mutate(jobId: current.id) {
+                $0.currentStep = Self.stepText(for: item, fallback: type)
+                $0.logs.append(CodexAgentLogEntry($0.currentStep))
+            }
+        case "item/completed":
+            guard let item = params["item"] as? [String: Any] else { return }
+            if let text = Self.agentMessageText(from: item), !text.isEmpty {
+                responseTextByJob[current.id] = text
+            }
+        case "thread/status/changed":
+            if let status = params["status"] as? [String: Any],
+               let type = status["type"] as? String,
+               type == "active",
+               ((status["activeFlags"] as? [String]) ?? []).contains(where: {
+                   $0 == "waitingOnApproval" || $0 == "waitingOnUserInput"
+               }) {
+                mutate(jobId: current.id) { $0.state = .waiting; $0.currentStep = "Waiting for input" }
+            }
+        case "item/commandExecution/requestApproval",
+             "item/fileChange/requestApproval",
+             "item/permissions/requestApproval",
+             "mcpServer/elicitation/request":
+            mutate(jobId: current.id) {
+                $0.currentStep = "Permission escalation declined"
+                $0.logs.append(CodexAgentLogEntry("Loop declined an unattended permission or external-input request."))
+            }
+        case "item/tool/requestUserInput":
+            mutate(jobId: current.id) {
+                $0.state = .running
+                $0.currentStep = "Continuing with best judgment"
+                $0.logs.append(CodexAgentLogEntry("Loop auto-resolved an unattended clarification request."))
+            }
+        case "turn/completed":
+            let turn = params["turn"] as? [String: Any]
+            let status = turn?["status"] as? String ?? "completed"
+            if status == "completed" {
+                finish(jobId: current.id, state: .completed, error: nil)
+            } else if status == "interrupted" || status == "cancelled" {
+                finish(jobId: current.id, state: .cancelled, error: nil)
+            } else {
+                let message = ((turn?["error"] as? [String: Any])?["message"] as? String)
+                    ?? "Codex turn ended with status \(status)."
+                finish(jobId: current.id, state: .failed, error: message)
+            }
+        default:
+            break
+        }
+    }
+
+    private static func stepText(for item: [String: Any], fallback: String) -> String {
+        if let command = item["command"] as? String, !command.isEmpty { return "Running: \(command)" }
+        if let name = item["name"] as? String, !name.isEmpty { return "Using \(name)" }
+        switch fallback {
+        case "commandExecution": return "Running a command"
+        case "fileChange": return "Editing files"
+        case "agentMessage": return "Writing the response"
+        default: return fallback.prefix(1).uppercased() + fallback.dropFirst()
+        }
+    }
+
+    private static func agentMessageText(from item: [String: Any]) -> String? {
+        if let text = item["text"] as? String { return text }
+        if let content = item["content"] as? [[String: Any]] {
+            let parts = content.compactMap { $0["text"] as? String }
+            return parts.isEmpty ? nil : parts.joined()
+        }
+        return nil
+    }
+
+    // MARK: - Persistence and completion
+
+    private func mutate(jobId: String, _ body: (inout CodexAgentJob) -> Void) {
+        var updated: CodexAgentJob?
+        queue.sync {
+            var jobs = loadJobsUnlocked()
+            guard let index = jobs.firstIndex(where: { $0.id == jobId }) else { return }
+            body(&jobs[index])
+            jobs[index].updatedAt = Date()
+            if jobs[index].logs.count > maxLogs {
+                jobs[index].logs.removeFirst(jobs[index].logs.count - maxLogs)
+            }
+            updated = jobs[index]
+            saveJobsUnlocked(jobs)
+        }
+        if let updated { broadcast(updated.id) }
+    }
+
+    private func upsert(_ job: CodexAgentJob) {
+        queue.sync {
+            var jobs = loadJobsUnlocked()
+            if let index = jobs.firstIndex(where: { $0.id == job.id }) { jobs[index] = job }
+            else { jobs.append(job) }
+            saveJobsUnlocked(jobs)
+        }
+        broadcast(job.id)
+    }
+
+    private func fail(jobId: String, message: String) {
+        finish(jobId: jobId, state: .failed, error: message)
+    }
+
+    private func finish(jobId: String, state: CodexAgentState, error: String?) {
+        let response = responseTextByJob.removeValue(forKey: jobId)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        mutate(jobId: jobId) {
+            $0.state = state
+            $0.currentStep = state == .completed ? "Completed" : state.rawValue.capitalized
+            $0.finalResponse = response?.isEmpty == false ? response : $0.finalResponse
+            $0.error = error
+            $0.logs.append(CodexAgentLogEntry(error ?? $0.currentStep))
+        }
+        postBackIfNeeded(jobId: jobId)
+    }
+
+    private func postBackIfNeeded(jobId: String) {
+        guard let job = job(id: jobId), job.isTerminal, !job.postedBack else { return }
+        let manager = SimpleConversationManager.shared
+        let parent = manager.getAllConversations().first(where: { $0.id == job.conversationId })
+            ?? manager.currentConversation
+            ?? manager.loadLastConversation()
+        guard let parent else { return }
+
+        let body: String
+        switch job.state {
+        case .completed:
+            body = "✅ Codex finished `\(URL(fileURLWithPath: job.projectPath).lastPathComponent)`.\n\n" +
+                (job.finalResponse ?? "The Codex turn completed without a final text response.")
+        case .cancelled:
+            body = "🚫 Codex agent for `\(URL(fileURLWithPath: job.projectPath).lastPathComponent)` was cancelled."
+        case .failed:
+            body = "❌ Codex agent for `\(URL(fileURLWithPath: job.projectPath).lastPathComponent)` failed: \(job.error ?? "Unknown error")"
+        case .queued, .running, .waiting:
+            return
+        }
+        var message = MessageStruct(role: "assistant", content: body, model: "Codex")
+        message.name = "codex_agent_\(job.id.prefix(8))"
+        manager.addMessage(message, to: parent)
+        mutate(jobId: job.id) { $0.postedBack = true }
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(
+                name: .codexAgentDidPostMessage,
+                object: nil,
+                userInfo: ["conversationId": parent.id, "messageId": message.id]
+            )
+            guard !NSApplication.shared.isActive else { return }
+            let content = UNMutableNotificationContent()
+            content.title = "Codex · \(URL(fileURLWithPath: job.projectPath).lastPathComponent)"
+            content.body = job.state == .completed ? "Agent completed" : body
+            content.sound = .default
+            UNUserNotificationCenter.current().add(UNNotificationRequest(
+                identifier: "loop.codex.\(job.id)",
+                content: content,
+                trigger: UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
+            ))
+        }
+    }
+
+    private func touchProject(_ id: String) {
+        queue.sync {
+            var projects = loadProjectsUnlocked()
+            guard let index = projects.firstIndex(where: { $0.id == id }) else { return }
+            projects[index].lastUsedAt = Date()
+            saveProjectsUnlocked(projects)
+        }
+    }
+
+    private func broadcast(_ jobId: String) {
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(
+                name: .codexAgentsDidChange,
+                object: nil,
+                userInfo: ["agentId": jobId]
+            )
+        }
+    }
+
+    private func loadProjectsUnlocked() -> [CodexProject] {
+        guard let data = UserDefaults.standard.data(forKey: projectsKey) else { return [] }
+        return (try? JSONDecoder().decode([CodexProject].self, from: data)) ?? []
+    }
+
+    private func saveProjectsUnlocked(_ projects: [CodexProject]) {
+        if let data = try? JSONEncoder().encode(projects) {
+            UserDefaults.standard.set(data, forKey: projectsKey)
+        }
+    }
+
+    private func loadJobsUnlocked() -> [CodexAgentJob] {
+        guard let data = UserDefaults.standard.data(forKey: jobsKey) else { return [] }
+        return (try? JSONDecoder().decode([CodexAgentJob].self, from: data)) ?? []
+    }
+
+    private func saveJobsUnlocked(_ jobs: [CodexAgentJob]) {
+        if let data = try? JSONEncoder().encode(jobs) {
+            UserDefaults.standard.set(data, forKey: jobsKey)
+        }
+    }
+}

--- a/LoopMac/Codex/CodexAppServerClient.swift
+++ b/LoopMac/Codex/CodexAppServerClient.swift
@@ -1,0 +1,304 @@
+//
+//  CodexAppServerClient.swift
+//  LoopMac
+//
+//  Owns one long-lived `codex app-server --listen stdio://` child process.
+//  App-server speaks newline-delimited JSON-RPC (without a `jsonrpc` field)
+//  over stdin/stdout. The client serializes all process and callback state on
+//  one queue and exposes only request/notification primitives to the service.
+//
+
+import Foundation
+
+final class CodexAppServerClient {
+    static let shared = CodexAppServerClient()
+
+    typealias JSONObject = [String: Any]
+    typealias NotificationHandler = (_ method: String, _ params: JSONObject) -> Void
+
+    private let queue = DispatchQueue(label: "loop.codex.app-server")
+    private var process: Process?
+    private var stdinHandle: FileHandle?
+    private var stdoutBuffer = Data()
+    private var nextRequestId = 1
+    private var pending: [Int: (Result<JSONObject, Error>) -> Void] = [:]
+    private var startupCallbacks: [(Result<Void, Error>) -> Void] = []
+    private var isReady = false
+    private var stderrTail = ""
+
+    var onNotification: NotificationHandler?
+
+    private init() {}
+
+    static func resolvedExecutablePath() -> String? {
+        let defaultsPath = UserDefaults.standard.string(forKey: "loop.codex.executablePath")?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        var candidates: [String] = []
+        if let defaultsPath, !defaultsPath.isEmpty { candidates.append(defaultsPath) }
+        if let path = ProcessInfo.processInfo.environment["PATH"] {
+            candidates.append(contentsOf: path.split(separator: ":").map { "\($0)/codex" })
+        }
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        candidates.append(contentsOf: [
+            "\(home)/.local/bin/codex",
+            "/opt/homebrew/bin/codex",
+            "/usr/local/bin/codex"
+        ])
+        return candidates.first { FileManager.default.isExecutableFile(atPath: $0) }
+    }
+
+    static var isAvailable: Bool {
+        resolvedExecutablePath() != nil && ProcessInfo.processInfo.environment["APP_SANDBOX_CONTAINER_ID"] == nil
+    }
+
+    func start(completion: @escaping (Result<Void, Error>) -> Void) {
+        queue.async {
+            if self.isReady {
+                DispatchQueue.main.async { completion(.success(())) }
+                return
+            }
+            self.startupCallbacks.append(completion)
+            guard self.process == nil else { return }
+            self.launch()
+        }
+    }
+
+    func stop() {
+        queue.async {
+            self.process?.terminationHandler = nil
+            if self.process?.isRunning == true { self.process?.terminate() }
+            self.failConnection(CodexAppServerError.terminated("Codex app-server stopped."))
+        }
+    }
+
+    func request(method: String,
+                 params: JSONObject = [:],
+                 completion: @escaping (Result<JSONObject, Error>) -> Void) {
+        start { result in
+            switch result {
+            case .failure(let error): completion(.failure(error))
+            case .success:
+                self.queue.async {
+                    let id = self.nextRequestId
+                    self.nextRequestId += 1
+                    self.pending[id] = completion
+                    do {
+                        try self.write(["method": method, "id": id, "params": params])
+                    } catch {
+                        self.pending.removeValue(forKey: id)
+                        DispatchQueue.main.async { completion(.failure(error)) }
+                    }
+                }
+            }
+        }
+    }
+
+    func notify(method: String, params: JSONObject = [:]) {
+        queue.async {
+            guard self.isReady else { return }
+            try? self.write(["method": method, "params": params])
+        }
+    }
+
+    private func launch() {
+        guard ProcessInfo.processInfo.environment["APP_SANDBOX_CONTAINER_ID"] == nil else {
+            finishStartup(.failure(CodexAppServerError.unavailable(
+                "Codex agents require the non-sandboxed Mac build because Loop must launch the local Codex CLI."
+            )))
+            return
+        }
+        guard let executable = Self.resolvedExecutablePath() else {
+            finishStartup(.failure(CodexAppServerError.executableNotFound))
+            return
+        }
+
+        let child = Process()
+        let input = Pipe()
+        let output = Pipe()
+        let errors = Pipe()
+        child.executableURL = URL(fileURLWithPath: executable)
+        child.arguments = ["app-server", "--listen", "stdio://"]
+        child.standardInput = input
+        child.standardOutput = output
+        child.standardError = errors
+        child.terminationHandler = { [weak self] process in
+            self?.queue.async {
+                let suffix = self?.stderrTail.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                let detail = suffix.isEmpty ? "" : " \(suffix)"
+                self?.failConnection(CodexAppServerError.terminated(
+                    "Codex app-server exited with status \(process.terminationStatus).\(detail)"
+                ))
+            }
+        }
+
+        output.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty else { return }
+            self?.queue.async { self?.consumeStdout(data) }
+        }
+        errors.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty, let text = String(data: data, encoding: .utf8) else { return }
+            self?.queue.async {
+                self?.stderrTail.append(text)
+                if let count = self?.stderrTail.count, count > 4_000 {
+                    self?.stderrTail = String(self?.stderrTail.suffix(4_000) ?? "")
+                }
+            }
+        }
+
+        do {
+            try child.run()
+            process = child
+            stdinHandle = input.fileHandleForWriting
+            let initializeId = nextRequestId
+            nextRequestId += 1
+            pending[initializeId] = { [weak self] result in
+                guard let self else { return }
+                switch result {
+                case .failure(let error): self.queue.async { self.finishStartup(.failure(error)) }
+                case .success:
+                    self.queue.async {
+                        do {
+                            try self.write(["method": "initialized", "params": [:]])
+                            self.isReady = true
+                            self.finishStartup(.success(()))
+                        } catch {
+                            self.finishStartup(.failure(error))
+                        }
+                    }
+                }
+            }
+            try write([
+                "method": "initialize",
+                "id": initializeId,
+                "params": [
+                    "clientInfo": [
+                        "name": "loop_harness",
+                        "title": "Loop Harness",
+                        "version": Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "dev"
+                    ]
+                ]
+            ])
+        } catch {
+            child.terminationHandler = nil
+            if child.isRunning { child.terminate() }
+            process = nil
+            stdinHandle = nil
+            finishStartup(.failure(error))
+        }
+    }
+
+    private func write(_ object: JSONObject) throws {
+        guard let stdinHandle else {
+            throw CodexAppServerError.unavailable("Codex app-server is not connected.")
+        }
+        var data = try JSONSerialization.data(withJSONObject: object)
+        data.append(0x0A)
+        try stdinHandle.write(contentsOf: data)
+    }
+
+    private func consumeStdout(_ data: Data) {
+        stdoutBuffer.append(data)
+        while let newline = stdoutBuffer.firstIndex(of: 0x0A) {
+            let line = stdoutBuffer[..<newline]
+            stdoutBuffer.removeSubrange(...newline)
+            guard !line.isEmpty,
+                  let value = try? JSONSerialization.jsonObject(with: Data(line)),
+                  let object = value as? JSONObject else { continue }
+            handleMessage(object)
+        }
+    }
+
+    private func handleMessage(_ object: JSONObject) {
+        if let id = (object["id"] as? NSNumber)?.intValue,
+           let callback = pending.removeValue(forKey: id) {
+            if let error = object["error"] as? JSONObject {
+                let result: Result<JSONObject, Error> = .failure(CodexAppServerError.server(
+                    code: (error["code"] as? NSNumber)?.intValue,
+                    message: error["message"] as? String ?? "Unknown error"
+                ))
+                DispatchQueue.main.async { callback(result) }
+            } else if let result = object["result"] as? JSONObject {
+                DispatchQueue.main.async { callback(.success(result)) }
+            } else {
+                let result: Result<JSONObject, Error> = .failure(CodexAppServerError.invalidResponse(
+                    "Codex returned an invalid response for request \(id)."
+                ))
+                DispatchQueue.main.async { callback(result) }
+            }
+            return
+        }
+        if let method = object["method"] as? String, object["id"] == nil {
+            let params = object["params"] as? JSONObject ?? [:]
+            DispatchQueue.main.async { [weak self] in self?.onNotification?(method, params) }
+            return
+        }
+        if let method = object["method"] as? String,
+           let requestId = object["id"] {
+            handleServerRequest(id: requestId,
+                                method: method,
+                                params: object["params"] as? JSONObject ?? [:])
+        }
+    }
+
+    /// Loop-dispatched turns are unattended, so server-initiated prompts
+    /// must never hang waiting for a hidden approval sheet. Stay inside the
+    /// configured sandbox, decline escalations, and give request_user_input a
+    /// deterministic best-judgment answer so the agent can finish or explain
+    /// the limitation in its final response.
+    private func handleServerRequest(id: Any,
+                                     method: String,
+                                     params: JSONObject) {
+        let result: JSONObject
+        switch method {
+        case "item/commandExecution/requestApproval",
+             "item/fileChange/requestApproval":
+            result = ["decision": "decline"]
+        case "item/permissions/requestApproval":
+            result = ["permissions": [:], "scope": "turn"]
+        case "mcpServer/elicitation/request":
+            result = ["action": "decline", "content": NSNull()]
+        case "item/tool/requestUserInput":
+            var answers: JSONObject = [:]
+            for question in params["questions"] as? [[String: Any]] ?? [] {
+                guard let questionId = question["id"] as? String else { continue }
+                let options = question["options"] as? [[String: Any]] ?? []
+                let answer = (options.first?["label"] as? String)
+                    ?? "Use your best judgment and continue without additional user input."
+                answers[questionId] = ["answers": [answer]]
+            }
+            result = ["answers": answers]
+        default:
+            try? write([
+                "id": id,
+                "error": ["code": -32601, "message": "Loop does not support server request \(method)."]
+            ])
+            DispatchQueue.main.async { [weak self] in self?.onNotification?(method, params) }
+            return
+        }
+        try? write(["id": id, "result": result])
+        DispatchQueue.main.async { [weak self] in self?.onNotification?(method, params) }
+    }
+
+    private func finishStartup(_ result: Result<Void, Error>) {
+        let callbacks = startupCallbacks
+        startupCallbacks.removeAll()
+        for callback in callbacks {
+            DispatchQueue.main.async { callback(result) }
+        }
+    }
+
+    private func failConnection(_ error: Error) {
+        process = nil
+        stdinHandle = nil
+        isReady = false
+        stdoutBuffer.removeAll(keepingCapacity: false)
+        let callbacks = pending.values
+        pending.removeAll()
+        for callback in callbacks {
+            DispatchQueue.main.async { callback(.failure(error)) }
+        }
+        finishStartup(.failure(error))
+    }
+}

--- a/LoopMac/Codex/CodexProtocol.swift
+++ b/LoopMac/Codex/CodexProtocol.swift
@@ -1,0 +1,121 @@
+//
+//  CodexProtocol.swift
+//  LoopMac
+//
+//  Small, deliberately stable model layer around the Codex app-server API.
+//  Wire payloads stay as JSON dictionaries in CodexAppServerClient so a CLI
+//  update can add fields without breaking decoding; only the state Loop owns
+//  (projects and dispatched jobs) is Codable and persisted locally.
+//
+
+import Foundation
+
+enum CodexAccessMode: String, Codable, CaseIterable {
+    /// Wire values from the generated app-server `SandboxMode` schema.
+    case readOnly = "read-only"
+    case workspaceWrite = "workspace-write"
+
+    var displayName: String {
+        switch self {
+        case .readOnly: return "Read only"
+        case .workspaceWrite: return "Workspace write"
+        }
+    }
+}
+
+struct CodexProject: Codable, Equatable, Identifiable {
+    var id: String
+    var name: String
+    var path: String
+    var defaultAccess: CodexAccessMode
+    var addedAt: Date
+    var lastUsedAt: Date?
+
+    init(path: String,
+         name: String? = nil,
+         defaultAccess: CodexAccessMode = .readOnly,
+         addedAt: Date = Date()) {
+        let standardized = URL(fileURLWithPath: path)
+            .resolvingSymlinksInPath().standardizedFileURL.path
+        self.id = standardized
+        let trimmedName = name?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.name = (trimmedName?.isEmpty == false ? trimmedName : nil)
+            ?? URL(fileURLWithPath: standardized).lastPathComponent
+        self.path = standardized
+        self.defaultAccess = defaultAccess
+        self.addedAt = addedAt
+        self.lastUsedAt = nil
+    }
+}
+
+enum CodexAgentState: String, Codable {
+    case queued
+    case running
+    case waiting
+    case completed
+    case cancelled
+    case failed
+
+    var isTerminal: Bool {
+        switch self {
+        case .completed, .cancelled, .failed: return true
+        case .queued, .running, .waiting: return false
+        }
+    }
+}
+
+struct CodexAgentLogEntry: Codable {
+    var date: Date
+    var summary: String
+
+    init(_ summary: String, date: Date = Date()) {
+        self.date = date
+        self.summary = summary
+    }
+}
+
+struct CodexAgentJob: Codable, Identifiable {
+    var id: String
+    var threadId: String?
+    var turnId: String?
+    var conversationId: String
+    var projectId: String
+    var projectPath: String
+    var task: String
+    var access: CodexAccessMode
+    var state: CodexAgentState
+    var currentStep: String
+    var createdAt: Date
+    var updatedAt: Date
+    var finalResponse: String?
+    var error: String?
+    var postedBack: Bool
+    var logs: [CodexAgentLogEntry]
+
+    var isTerminal: Bool { state.isTerminal }
+
+    var displayTitle: String {
+        let oneLine = task.replacingOccurrences(of: "\n", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return oneLine.count > 80 ? String(oneLine.prefix(77)) + "…" : oneLine
+    }
+}
+
+enum CodexAppServerError: LocalizedError {
+    case executableNotFound
+    case unavailable(String)
+    case invalidResponse(String)
+    case server(code: Int?, message: String)
+    case terminated(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .executableNotFound:
+            return "Codex CLI was not found. Install it, or set its path in Loop's Codex integration settings."
+        case .unavailable(let message), .invalidResponse(let message), .terminated(let message):
+            return message
+        case .server(let code, let message):
+            return code.map { "Codex app-server error \($0): \(message)" } ?? "Codex app-server error: \(message)"
+        }
+    }
+}

--- a/LoopMac/Codex/CodexSkill.swift
+++ b/LoopMac/Codex/CodexSkill.swift
@@ -1,0 +1,328 @@
+//
+//  CodexSkill.swift
+//  LoopMac
+//
+//  Model-facing tools for discovering local projects and dispatching Codex
+//  app-server agents into one or several of them. Long-running calls return
+//  immediately; CodexAgentService publishes progress and posts the terminal
+//  response back into the originating Loop conversation.
+//
+
+import Foundation
+
+struct CodexSkill {
+    static let shared = CodexSkill()
+
+    static let systemPromptFragment = """
+You can delegate repository work to local Codex agents on this Mac.
+- codex_list_projects discovers projects from Codex history and lists projects explicitly registered with Loop.
+- codex_add_project registers an existing local directory. Projects default to read-only; set allow_writes only when the user has asked Codex to make changes there.
+- codex_dispatch_agent starts one agent and returns immediately. Use project_id from codex_list_projects. Access defaults to the project's policy; workspace_write is rejected unless writes were explicitly enabled for that project.
+- codex_dispatch_agents starts up to three independent project tasks at once. Use it when the user asks to fan work out across projects.
+- codex_list_agents reports live and completed jobs; codex_continue_agent sends a follow-up on a completed thread; codex_cancel_agent interrupts an active turn.
+
+After dispatch, tell the user the agent is running. Do not wait or claim work is complete: Loop posts the result back into this conversation when the Codex turn ends. Never request unrestricted filesystem access; only read_only and workspace_write are supported.
+"""
+
+    static let tools: [[String: Any]] = [
+        tool("codex_list_projects",
+             "List local projects available to Codex. Optionally refresh from Codex thread history first.",
+             properties: [
+                "refresh": ["type": "boolean", "description": "Refresh projects from local Codex history before listing (default true)."]
+             ]),
+        tool("codex_add_project",
+             "Register an existing local directory as a Codex project.",
+             properties: [
+                "path": ["type": "string", "description": "Absolute path to an existing project directory."],
+                "name": ["type": "string", "description": "Optional display name."],
+                "allow_writes": ["type": "boolean", "description": "Allow workspace-write Codex agents in this project (default false)."]
+             ], required: ["path"]),
+        tool("codex_dispatch_agent",
+             "Start a local Codex agent in one registered project. Returns immediately and posts the final result back later.",
+             properties: [
+                "project_id": ["type": "string", "description": "Project id/path/name from codex_list_projects."],
+                "task": ["type": "string", "description": "Clear, self-contained task for Codex."],
+                "access": ["type": "string", "enum": ["read_only", "workspace_write"], "description": "Filesystem access. Defaults to the project's configured policy."]
+             ], required: ["project_id", "task"]),
+        tool("codex_dispatch_agents",
+             "Fan out independent Codex tasks across up to three registered projects.",
+             properties: [
+                "tasks": [
+                    "type": "array",
+                    "maxItems": 3,
+                    "items": [
+                        "type": "object",
+                        "properties": [
+                            "project_id": ["type": "string"],
+                            "task": ["type": "string"],
+                            "access": ["type": "string", "enum": ["read_only", "workspace_write"]]
+                        ],
+                        "required": ["project_id", "task"]
+                    ]
+                ]
+             ], required: ["tasks"]),
+        tool("codex_list_agents",
+             "List Codex agents tracked by Loop, including live state and final result.",
+             properties: [
+                "project_id": ["type": "string", "description": "Optional project id/path/name filter."]
+             ]),
+        tool("codex_continue_agent",
+             "Continue a completed Codex thread with a follow-up instruction.",
+             properties: [
+                "agent_id": ["type": "string"],
+                "instruction": ["type": "string"]
+             ], required: ["agent_id", "instruction"]),
+        tool("codex_cancel_agent",
+             "Interrupt a currently running Codex agent turn.",
+             properties: ["agent_id": ["type": "string"]],
+             required: ["agent_id"])
+    ]
+
+    private static let names = Set(tools.compactMap {
+        ($0["function"] as? [String: Any])?["name"] as? String
+    })
+
+    func handles(functionName: String) -> Bool { Self.names.contains(functionName) }
+
+    func statusText(for call: FunctionCallStruct) -> String? {
+        switch call.name {
+        case "codex_list_projects": return "discovering Codex projects"
+        case "codex_add_project": return "registering a Codex project"
+        case "codex_dispatch_agent": return "starting a Codex agent"
+        case "codex_dispatch_agents": return "starting Codex agents"
+        case "codex_list_agents": return "checking Codex agents"
+        case "codex_continue_agent": return "continuing a Codex agent"
+        case "codex_cancel_agent": return "stopping a Codex agent"
+        default: return nil
+        }
+    }
+
+    func handle(functionCall: FunctionCallStruct,
+                completion: @escaping (MessageStruct) -> Void) {
+        switch functionCall.name {
+        case "codex_list_projects": listProjects(functionCall.arguments, completion)
+        case "codex_add_project": addProject(functionCall.arguments, completion)
+        case "codex_dispatch_agent": dispatchOne(functionCall.arguments, completion)
+        case "codex_dispatch_agents": dispatchMany(functionCall.arguments, completion)
+        case "codex_list_agents": listAgents(functionCall.arguments, completion)
+        case "codex_continue_agent": continueAgent(functionCall.arguments, completion)
+        case "codex_cancel_agent": cancelAgent(functionCall.arguments, completion)
+        default: completion(Self.result(functionCall.name, ["status": "error", "error": "Unknown Codex tool."]))
+        }
+    }
+
+    private func listProjects(_ args: [String: Any], _ completion: @escaping (MessageStruct) -> Void) {
+        let finish: ([CodexProject]) -> Void = { projects in
+            completion(Self.result("codex_list_projects", [
+                "count": projects.count,
+                "projects": projects.map(Self.projectPayload)
+            ]))
+        }
+        if (args["refresh"] as? Bool) ?? true {
+            CodexAgentService.shared.refreshProjects { result in
+                switch result {
+                case .success(let projects): finish(projects)
+                case .failure(let error):
+                    let cached = CodexAgentService.shared.projects()
+                    completion(Self.result("codex_list_projects", [
+                        "status": "partial",
+                        "warning": error.localizedDescription,
+                        "count": cached.count,
+                        "projects": cached.map(Self.projectPayload)
+                    ]))
+                }
+            }
+        } else {
+            finish(CodexAgentService.shared.projects())
+        }
+    }
+
+    private func addProject(_ args: [String: Any], _ completion: @escaping (MessageStruct) -> Void) {
+        guard let path = Self.string(args, "path") else {
+            completion(Self.error("codex_add_project", "path is required")); return
+        }
+        switch CodexAgentService.shared.addProject(
+            path: path,
+            name: Self.string(args, "name"),
+            allowWrites: (args["allow_writes"] as? Bool) ?? false
+        ) {
+        case .success(let project):
+            completion(Self.result("codex_add_project", ["status": "registered", "project": Self.projectPayload(project)]))
+        case .failure(let error):
+            completion(Self.error("codex_add_project", error.localizedDescription))
+        }
+    }
+
+    private func dispatchOne(_ args: [String: Any], _ completion: @escaping (MessageStruct) -> Void) {
+        dispatchPayload(args) { payload in
+            completion(Self.result("codex_dispatch_agent", payload))
+        }
+    }
+
+    private func dispatchMany(_ args: [String: Any], _ completion: @escaping (MessageStruct) -> Void) {
+        guard let tasks = args["tasks"] as? [[String: Any]], !tasks.isEmpty else {
+            completion(Self.error("codex_dispatch_agents", "tasks must contain at least one task")); return
+        }
+        guard tasks.count <= 3 else {
+            completion(Self.error("codex_dispatch_agents", "A maximum of three agents can be dispatched at once.")); return
+        }
+        var payloads = Array(repeating: [String: Any](), count: tasks.count)
+        let group = DispatchGroup()
+        for (index, task) in tasks.enumerated() {
+            group.enter()
+            dispatchPayload(task) { payload in
+                payloads[index] = payload
+                group.leave()
+            }
+        }
+        group.notify(queue: .main) {
+            let dispatched = payloads.filter { ($0["status"] as? String) == "dispatched" }.count
+            completion(Self.result("codex_dispatch_agents", [
+                "status": dispatched == payloads.count ? "dispatched" : "partial",
+                "dispatched": dispatched,
+                "results": payloads,
+                "message": "Started \(dispatched) Codex agent(s). Results will be posted back into this conversation when each turn completes."
+            ]))
+        }
+    }
+
+    private func dispatchPayload(_ args: [String: Any], completion: @escaping ([String: Any]) -> Void) {
+        guard let identifier = Self.string(args, "project_id") else {
+            completion(["status": "error", "error": "project_id is required"]); return
+        }
+        guard let task = Self.string(args, "task") else {
+            completion(["status": "error", "project_id": identifier, "error": "task is required"]); return
+        }
+        guard let project = CodexAgentService.shared.project(matching: identifier) else {
+            completion(["status": "error", "project_id": identifier, "error": "Unknown project. Call codex_list_projects or codex_add_project first."])
+            return
+        }
+        let access: CodexAccessMode
+        switch Self.string(args, "access") {
+        case "read_only": access = .readOnly
+        case "workspace_write": access = .workspaceWrite
+        case nil: access = project.defaultAccess
+        default:
+            completion(["status": "error", "project_id": identifier, "error": "access must be read_only or workspace_write"])
+            return
+        }
+        CodexAgentService.shared.dispatch(
+            task: task,
+            project: project,
+            access: access,
+            conversationId: Self.conversationId()
+        ) { result in
+            switch result {
+            case .success(let job):
+                completion([
+                    "status": "dispatched",
+                    "agent_id": job.id,
+                    "thread_id": job.threadId ?? "",
+                    "project": project.name,
+                    "access": access == .workspaceWrite ? "workspace_write" : "read_only",
+                    "message": "Codex is running. Loop will post the final result back into this conversation."
+                ])
+            case .failure(let error):
+                completion(["status": "error", "project": project.name, "error": error])
+            }
+        }
+    }
+
+    private func listAgents(_ args: [String: Any], _ completion: @escaping (MessageStruct) -> Void) {
+        var jobs = CodexAgentService.shared.allJobs()
+        if let identifier = Self.string(args, "project_id") {
+            guard let project = CodexAgentService.shared.project(matching: identifier) else {
+                completion(Self.error("codex_list_agents", "Unknown project \(identifier).")); return
+            }
+            jobs = jobs.filter { $0.projectId == project.id }
+        }
+        completion(Self.result("codex_list_agents", [
+            "count": jobs.count,
+            "agents": jobs.map(Self.jobPayload)
+        ]))
+    }
+
+    private func continueAgent(_ args: [String: Any], _ completion: @escaping (MessageStruct) -> Void) {
+        guard let id = Self.string(args, "agent_id"), let instruction = Self.string(args, "instruction") else {
+            completion(Self.error("codex_continue_agent", "agent_id and instruction are required")); return
+        }
+        CodexAgentService.shared.continueAgent(id: id, instruction: instruction) { result in
+            switch result {
+            case .success(let job): completion(Self.result("codex_continue_agent", ["status": "running", "agent": Self.jobPayload(job)]))
+            case .failure(let error): completion(Self.error("codex_continue_agent", error.localizedDescription))
+            }
+        }
+    }
+
+    private func cancelAgent(_ args: [String: Any], _ completion: @escaping (MessageStruct) -> Void) {
+        guard let id = Self.string(args, "agent_id") else {
+            completion(Self.error("codex_cancel_agent", "agent_id is required")); return
+        }
+        CodexAgentService.shared.cancel(id: id) { result in
+            switch result {
+            case .success(let job): completion(Self.result("codex_cancel_agent", ["status": "cancelled", "agent": Self.jobPayload(job)]))
+            case .failure(let error): completion(Self.error("codex_cancel_agent", error.localizedDescription))
+            }
+        }
+    }
+
+    private static func tool(_ name: String,
+                             _ description: String,
+                             properties: [String: Any],
+                             required: [String] = []) -> [String: Any] {
+        ["type": "function", "function": [
+            "name": name,
+            "description": description,
+            "parameters": ["type": "object", "properties": properties, "required": required]
+        ]]
+    }
+
+    private static func string(_ args: [String: Any], _ key: String) -> String? {
+        guard let value = (args[key] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else { return nil }
+        return value
+    }
+
+    private static func conversationId() -> String {
+        let manager = SimpleConversationManager.shared
+        if let current = manager.currentConversation { return current.id }
+        if let last = manager.loadLastConversation() { return last.id }
+        let fresh = manager.createConversation(title: "Codex results")
+        manager.currentConversation = fresh
+        return fresh.id
+    }
+
+    private static func projectPayload(_ project: CodexProject) -> [String: Any] {
+        [
+            "id": project.id,
+            "name": project.name,
+            "path": project.path,
+            "default_access": project.defaultAccess == .workspaceWrite ? "workspace_write" : "read_only"
+        ]
+    }
+
+    private static func jobPayload(_ job: CodexAgentJob) -> [String: Any] {
+        [
+            "agent_id": job.id,
+            "thread_id": job.threadId ?? "",
+            "project_id": job.projectId,
+            "project_path": job.projectPath,
+            "task": job.task,
+            "access": job.access == .workspaceWrite ? "workspace_write" : "read_only",
+            "status": job.state.rawValue,
+            "current_step": job.currentStep,
+            "final_response": job.finalResponse ?? "",
+            "error": job.error ?? ""
+        ]
+    }
+
+    private static func result(_ name: String, _ payload: [String: Any]) -> MessageStruct {
+        let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+        let content = data.flatMap { String(data: $0, encoding: .utf8) }
+            ?? "{\"status\":\"error\",\"error\":\"failed to encode result\"}"
+        return MessageStruct(role: "function", content: content, name: name)
+    }
+
+    private static func error(_ name: String, _ message: String) -> MessageStruct {
+        result(name, ["status": "error", "error": message])
+    }
+}

--- a/LoopMac/Codex/CodexWindows.swift
+++ b/LoopMac/Codex/CodexWindows.swift
@@ -1,0 +1,389 @@
+//
+//  CodexWindows.swift
+//  LoopMac
+//
+//  Native Mac management surfaces for the Codex CLI integration: a project
+//  registry/status window and a lightweight persisted job detail window.
+//
+
+import AppKit
+
+final class CodexIntegrationWindowController: NSWindowController,
+                                               NSTableViewDataSource,
+                                               NSTableViewDelegate {
+    static let shared = CodexIntegrationWindowController()
+
+    private let statusLabel = NSTextField(labelWithString: "Checking Codex…")
+    private let executableField = NSTextField()
+    private let tableView = NSTableView()
+    private var projects: [CodexProject] = []
+
+    private init() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 680, height: 430),
+            styleMask: [.titled, .closable, .resizable, .miniaturizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "Codex Projects"
+        window.minSize = NSSize(width: 560, height: 340)
+        window.isReleasedWhenClosed = false
+        super.init(window: window)
+        configure()
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(projectsDidChange), name: .codexProjectsDidChange, object: nil
+        )
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+    deinit { NotificationCenter.default.removeObserver(self) }
+
+    func show() {
+        reload()
+        checkStatus()
+        showWindow(nil)
+        window?.center()
+        window?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    private func configure() {
+        guard let window else { return }
+        let content = NSView()
+
+        let heading = NSTextField(labelWithString: "Local Codex agents")
+        heading.font = .systemFont(ofSize: 17, weight: .semibold)
+        heading.translatesAutoresizingMaskIntoConstraints = false
+        content.addSubview(heading)
+
+        statusLabel.font = .systemFont(ofSize: 12)
+        statusLabel.textColor = .secondaryLabelColor
+        statusLabel.translatesAutoresizingMaskIntoConstraints = false
+        content.addSubview(statusLabel)
+
+        let executableLabel = NSTextField(labelWithString: "CLI path")
+        executableLabel.font = .systemFont(ofSize: 11, weight: .medium)
+        executableLabel.translatesAutoresizingMaskIntoConstraints = false
+        content.addSubview(executableLabel)
+
+        executableField.placeholderString = "Auto-detect Codex CLI"
+        executableField.stringValue = UserDefaults.standard.string(forKey: "loop.codex.executablePath") ?? ""
+        executableField.translatesAutoresizingMaskIntoConstraints = false
+        executableField.target = self
+        executableField.action = #selector(saveExecutablePath)
+        content.addSubview(executableField)
+
+        let saveButton = NSButton(title: "Save & Check", target: self, action: #selector(saveExecutablePath))
+        saveButton.bezelStyle = .rounded
+        saveButton.translatesAutoresizingMaskIntoConstraints = false
+        content.addSubview(saveButton)
+
+        let scroll = NSScrollView()
+        scroll.translatesAutoresizingMaskIntoConstraints = false
+        scroll.hasVerticalScroller = true
+        scroll.borderType = .bezelBorder
+        content.addSubview(scroll)
+
+        let nameColumn = NSTableColumn(identifier: .init("name"))
+        nameColumn.title = "Project"
+        nameColumn.width = 150
+        let pathColumn = NSTableColumn(identifier: .init("path"))
+        pathColumn.title = "Path"
+        pathColumn.width = 390
+        let accessColumn = NSTableColumn(identifier: .init("access"))
+        accessColumn.title = "Access"
+        accessColumn.width = 100
+        [nameColumn, pathColumn, accessColumn].forEach(tableView.addTableColumn)
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.usesAlternatingRowBackgroundColors = true
+        tableView.allowsMultipleSelection = false
+        scroll.documentView = tableView
+
+        let addButton = NSButton(title: "Add Project…", target: self, action: #selector(addProject))
+        let refreshButton = NSButton(title: "Discover from Codex", target: self, action: #selector(refreshProjects))
+        let accessButton = NSButton(title: "Toggle Write Access", target: self, action: #selector(toggleAccess))
+        let removeButton = NSButton(title: "Remove", target: self, action: #selector(removeProject))
+        let buttons = NSStackView(views: [addButton, refreshButton, accessButton, removeButton])
+        buttons.orientation = .horizontal
+        buttons.spacing = 8
+        buttons.translatesAutoresizingMaskIntoConstraints = false
+        content.addSubview(buttons)
+
+        let footnote = NSTextField(wrappingLabelWithString:
+            "Projects discovered from Codex start read-only. Enable write access explicitly before Loop can dispatch an agent that changes files. Loop never requests unrestricted filesystem access."
+        )
+        footnote.font = .systemFont(ofSize: 11)
+        footnote.textColor = .secondaryLabelColor
+        footnote.translatesAutoresizingMaskIntoConstraints = false
+        content.addSubview(footnote)
+
+        NSLayoutConstraint.activate([
+            heading.topAnchor.constraint(equalTo: content.topAnchor, constant: 18),
+            heading.leadingAnchor.constraint(equalTo: content.leadingAnchor, constant: 20),
+            statusLabel.leadingAnchor.constraint(equalTo: heading.trailingAnchor, constant: 12),
+            statusLabel.centerYAnchor.constraint(equalTo: heading.centerYAnchor),
+            statusLabel.trailingAnchor.constraint(lessThanOrEqualTo: content.trailingAnchor, constant: -20),
+
+            executableLabel.topAnchor.constraint(equalTo: heading.bottomAnchor, constant: 16),
+            executableLabel.leadingAnchor.constraint(equalTo: heading.leadingAnchor),
+            executableLabel.centerYAnchor.constraint(equalTo: executableField.centerYAnchor),
+            executableField.leadingAnchor.constraint(equalTo: executableLabel.trailingAnchor, constant: 10),
+            executableField.trailingAnchor.constraint(equalTo: saveButton.leadingAnchor, constant: -8),
+            saveButton.trailingAnchor.constraint(equalTo: content.trailingAnchor, constant: -20),
+            saveButton.centerYAnchor.constraint(equalTo: executableField.centerYAnchor),
+
+            scroll.topAnchor.constraint(equalTo: executableField.bottomAnchor, constant: 14),
+            scroll.leadingAnchor.constraint(equalTo: heading.leadingAnchor),
+            scroll.trailingAnchor.constraint(equalTo: content.trailingAnchor, constant: -20),
+            scroll.bottomAnchor.constraint(equalTo: buttons.topAnchor, constant: -12),
+
+            buttons.leadingAnchor.constraint(equalTo: heading.leadingAnchor),
+            buttons.bottomAnchor.constraint(equalTo: footnote.topAnchor, constant: -12),
+            footnote.leadingAnchor.constraint(equalTo: heading.leadingAnchor),
+            footnote.trailingAnchor.constraint(equalTo: content.trailingAnchor, constant: -20),
+            footnote.bottomAnchor.constraint(equalTo: content.bottomAnchor, constant: -16)
+        ])
+        window.contentView = content
+    }
+
+    @objc private func projectsDidChange() { reload() }
+
+    private func reload() {
+        projects = CodexAgentService.shared.projects()
+        tableView.reloadData()
+    }
+
+    private func checkStatus() {
+        statusLabel.stringValue = "Checking Codex…"
+        CodexAgentService.shared.status { [weak self] status in
+            self?.statusLabel.stringValue = status
+        }
+    }
+
+    @objc private func saveExecutablePath() {
+        let path = executableField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        if path.isEmpty { UserDefaults.standard.removeObject(forKey: "loop.codex.executablePath") }
+        else { UserDefaults.standard.set(path, forKey: "loop.codex.executablePath") }
+        CodexAppServerClient.shared.stop()
+        checkStatus()
+    }
+
+    @objc private func addProject() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.prompt = "Add Project"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        let alert = NSAlert()
+        alert.messageText = "Allow Codex to change files?"
+        alert.informativeText = "Read-only is safest and is enough for audits, explanations, and planning. You can enable writes later."
+        alert.addButton(withTitle: "Read Only")
+        alert.addButton(withTitle: "Allow Writes")
+        alert.addButton(withTitle: "Cancel")
+        let response = alert.runModal()
+        guard response != .alertThirdButtonReturn else { return }
+        let result = CodexAgentService.shared.addProject(
+            path: url.path,
+            allowWrites: response == .alertSecondButtonReturn
+        )
+        if case .failure(let error) = result { showError(error.localizedDescription) }
+    }
+
+    @objc private func refreshProjects() {
+        statusLabel.stringValue = "Discovering projects…"
+        CodexAgentService.shared.refreshProjects { [weak self] result in
+            switch result {
+            case .success(let projects): self?.statusLabel.stringValue = "Found \(projects.count) project(s)"
+            case .failure(let error): self?.showError(error.localizedDescription); self?.checkStatus()
+            }
+            self?.reload()
+        }
+    }
+
+    @objc private func toggleAccess() {
+        guard tableView.selectedRow >= 0, tableView.selectedRow < projects.count else { return }
+        let project = projects[tableView.selectedRow]
+        _ = CodexAgentService.shared.addProject(
+            path: project.path,
+            name: project.name,
+            allowWrites: project.defaultAccess != .workspaceWrite
+        )
+    }
+
+    @objc private func removeProject() {
+        guard tableView.selectedRow >= 0, tableView.selectedRow < projects.count else { return }
+        if case .failure(let error) = CodexAgentService.shared.removeProject(id: projects[tableView.selectedRow].id) {
+            showError(error.localizedDescription)
+        }
+    }
+
+    private func showError(_ message: String) {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Codex integration"
+        alert.informativeText = message
+        alert.runModal()
+    }
+
+    func numberOfRows(in tableView: NSTableView) -> Int { projects.count }
+
+    func tableView(_ tableView: NSTableView,
+                   viewFor tableColumn: NSTableColumn?,
+                   row: Int) -> NSView? {
+        guard projects.indices.contains(row), let tableColumn else { return nil }
+        let id = NSUserInterfaceItemIdentifier("CodexProjectCell")
+        let cell = tableView.makeView(withIdentifier: id, owner: nil) as? NSTableCellView ?? NSTableCellView()
+        cell.identifier = id
+        let label = cell.textField ?? NSTextField(labelWithString: "")
+        if cell.textField == nil {
+            label.translatesAutoresizingMaskIntoConstraints = false
+            label.lineBreakMode = .byTruncatingMiddle
+            cell.addSubview(label)
+            cell.textField = label
+            NSLayoutConstraint.activate([
+                label.leadingAnchor.constraint(equalTo: cell.leadingAnchor, constant: 4),
+                label.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -4),
+                label.centerYAnchor.constraint(equalTo: cell.centerYAnchor)
+            ])
+        }
+        let project = projects[row]
+        switch tableColumn.identifier.rawValue {
+        case "name": label.stringValue = project.name
+        case "path": label.stringValue = project.path
+        default: label.stringValue = project.defaultAccess.displayName
+        }
+        return cell
+    }
+}
+
+final class CodexAgentDetailWindowController: NSWindowController {
+    private static var open: [String: CodexAgentDetailWindowController] = [:]
+
+    static func show(agentId: String) {
+        if let existing = open[agentId] {
+            existing.window?.makeKeyAndOrderFront(nil)
+            return
+        }
+        let controller = CodexAgentDetailWindowController(agentId: agentId)
+        open[agentId] = controller
+        controller.showWindow(nil)
+        controller.window?.center()
+        controller.window?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    private let agentId: String
+    private let heading = NSTextField(labelWithString: "")
+    private let status = NSTextField(labelWithString: "")
+    private let textView = NSTextView()
+    private let actionButton = NSButton()
+
+    private init(agentId: String) {
+        self.agentId = agentId
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 620, height: 500),
+            styleMask: [.titled, .closable, .resizable, .miniaturizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "Codex Agent"
+        window.isReleasedWhenClosed = false
+        super.init(window: window)
+        window.delegate = self
+        configure()
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(reload), name: .codexAgentsDidChange, object: nil
+        )
+        reload()
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+    deinit { NotificationCenter.default.removeObserver(self) }
+
+    private func configure() {
+        guard let window else { return }
+        let content = NSView()
+        heading.font = .systemFont(ofSize: 15, weight: .semibold)
+        heading.lineBreakMode = .byTruncatingTail
+        status.font = .systemFont(ofSize: 11)
+        status.textColor = .secondaryLabelColor
+        for view in [heading, status] {
+            view.translatesAutoresizingMaskIntoConstraints = false
+            content.addSubview(view)
+        }
+        let scroll = NSScrollView()
+        scroll.translatesAutoresizingMaskIntoConstraints = false
+        scroll.hasVerticalScroller = true
+        scroll.borderType = .bezelBorder
+        textView.isEditable = false
+        textView.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+        textView.textContainerInset = NSSize(width: 10, height: 10)
+        scroll.documentView = textView
+        content.addSubview(scroll)
+        actionButton.target = self
+        actionButton.action = #selector(action)
+        actionButton.bezelStyle = .rounded
+        actionButton.translatesAutoresizingMaskIntoConstraints = false
+        content.addSubview(actionButton)
+        NSLayoutConstraint.activate([
+            heading.topAnchor.constraint(equalTo: content.topAnchor, constant: 16),
+            heading.leadingAnchor.constraint(equalTo: content.leadingAnchor, constant: 16),
+            heading.trailingAnchor.constraint(equalTo: content.trailingAnchor, constant: -16),
+            status.topAnchor.constraint(equalTo: heading.bottomAnchor, constant: 3),
+            status.leadingAnchor.constraint(equalTo: heading.leadingAnchor),
+            status.trailingAnchor.constraint(equalTo: heading.trailingAnchor),
+            scroll.topAnchor.constraint(equalTo: status.bottomAnchor, constant: 12),
+            scroll.leadingAnchor.constraint(equalTo: heading.leadingAnchor),
+            scroll.trailingAnchor.constraint(equalTo: heading.trailingAnchor),
+            scroll.bottomAnchor.constraint(equalTo: actionButton.topAnchor, constant: -12),
+            actionButton.trailingAnchor.constraint(equalTo: heading.trailingAnchor),
+            actionButton.bottomAnchor.constraint(equalTo: content.bottomAnchor, constant: -14)
+        ])
+        window.contentView = content
+    }
+
+    @objc private func reload() {
+        guard let job = CodexAgentService.shared.job(id: agentId) else { return }
+        heading.stringValue = job.displayTitle
+        let project = URL(fileURLWithPath: job.projectPath).lastPathComponent
+        status.stringValue = "\(project) · \(job.state.rawValue.capitalized) · \(job.access.displayName) · \(job.currentStep)"
+        let log = job.logs.map { "[\(Self.time.string(from: $0.date))] \($0.summary)" }.joined(separator: "\n")
+        var sections = ["TASK\n\(job.task)", "ACTIVITY\n\(log)"]
+        if let response = job.finalResponse { sections.append("RESULT\n\(response)") }
+        if let error = job.error { sections.append("ERROR\n\(error)") }
+        textView.string = sections.joined(separator: "\n\n")
+        actionButton.title = job.isTerminal ? "Continue…" : "Cancel Agent"
+    }
+
+    @objc private func action() {
+        guard let job = CodexAgentService.shared.job(id: agentId) else { return }
+        if job.isTerminal {
+            let alert = NSAlert()
+            alert.messageText = "Continue Codex agent"
+            alert.informativeText = "Enter a follow-up instruction for the same Codex thread."
+            alert.addButton(withTitle: "Continue")
+            alert.addButton(withTitle: "Cancel")
+            let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 420, height: 24))
+            alert.accessoryView = field
+            guard alert.runModal() == .alertFirstButtonReturn,
+                  !field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+            CodexAgentService.shared.continueAgent(id: agentId, instruction: field.stringValue) { _ in }
+        } else {
+            CodexAgentService.shared.cancel(id: agentId) { _ in }
+        }
+    }
+
+    private static let time: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss"
+        return formatter
+    }()
+}
+
+extension CodexAgentDetailWindowController: NSWindowDelegate {
+    func windowWillClose(_ notification: Notification) {
+        Self.open.removeValue(forKey: agentId)
+    }
+}

--- a/LoopMac/ConversationWindowController.swift
+++ b/LoopMac/ConversationWindowController.swift
@@ -199,6 +199,12 @@ final class ConversationWindowController: NSWindowController, ConversationPresen
             name: .cursorAgentDidPostMessage,
             object: nil
         )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(subAgentDidPostMessage(_:)),
+            name: .codexAgentDidPostMessage,
+            object: nil
+        )
         // Each coordinator broadcasts its state transitions; refresh the tab
         // bar so the "running" dot can appear/disappear on background tabs.
         NotificationCenter.default.addObserver(

--- a/LoopMac/IntegrationsWindowController.swift
+++ b/LoopMac/IntegrationsWindowController.swift
@@ -170,11 +170,29 @@ fileprivate final class IntegrationsListViewController: NSViewController, NSTabl
                 handler: nil
             ),
             slackIntegration(),
+            codexIntegration(),
             devinIntegration(),
             twitterIntegration(),
         ]
 
         tableView.reloadData()
+    }
+
+    /// Local Codex app-server integration. Authentication is owned by the
+    /// Codex CLI, so this row reports whether Loop can resolve the executable;
+    /// the detail window performs a live account/read check.
+    private func codexIntegration() -> Integration {
+        let available = CodexAppServerClient.isAvailable
+        return Integration(
+            title: "Codex",
+            subtitle: available
+                ? "Installed · manage local projects and agent access"
+                : "Install Codex CLI or configure its executable path",
+            icon: "terminal",
+            tint: .systemIndigo,
+            status: available ? .connected : .notConnected,
+            handler: { _ in CodexIntegrationWindowController.shared.show() }
+        )
     }
 
     /// Devin coding agent. The v3 API needs both a cog_… API key AND an

--- a/LoopMac/LoopMacApp.swift
+++ b/LoopMac/LoopMacApp.swift
@@ -87,6 +87,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         )
 
+        // Local Codex integration. The model can discover registered project
+        // directories and fan app-server agents out across them. It is Mac-
+        // only because the transport owns a local Codex CLI child process.
+        AgentHarness.shared.registerSkill(
+            tools: CodexSkill.tools,
+            systemPromptFragment: CodexSkill.systemPromptFragment
+        )
+        SkillDispatcher.shared.register(
+            handles: { CodexSkill.shared.handles(functionName: $0) },
+            handle: { call, completion in
+                CodexSkill.shared.handle(functionCall: call, completion: completion)
+            }
+        )
+        CodexAgentService.shared.resumePending()
+
         // Image generation. ImageSkill itself is target-agnostic — the iOS
         // build registers it via the global `tools` constant; on Mac we wire
         // it explicitly here, alongside the host plumbing below, so the model

--- a/LoopMac/MacTTS.swift
+++ b/LoopMac/MacTTS.swift
@@ -99,9 +99,10 @@ final class TTSSettings {
         ("Hannah (american female)",      "ZSNL4hPqCnqoMPaI4jGX"),
         ("Zoe (african american female)", "M6ic45wruJGWAxLFEMNK"),
         ("Agent (secret agent male)",     "ICIc5IiEgLitxGwyb7ZG"),
+        ("Friendly Californian",          "c3VtJKuoGvBc0vUNQf8k"),
     ]
 
-    private static let elevenLabsDefaultVoiceId = "21m00Tcm4TlvDq8ikWAM"
+    private static let elevenLabsDefaultVoiceId = "c3VtJKuoGvBc0vUNQf8k"
 
     func elevenLabsVoice(for provider: MacTTSProvider) -> String {
         switch provider {

--- a/LoopMac/SubAgentMacUI.swift
+++ b/LoopMac/SubAgentMacUI.swift
@@ -159,12 +159,13 @@ final class SubAgentMacStatusBar: NSView {
 
 // MARK: - Inspector window
 
-/// Lightweight wrapper for Devin/Cursor cloud agent rows in the Mac inspector.
+/// Lightweight wrapper for remote and local coding-agent rows in the Mac inspector.
 /// Mirrors the iPhone `CloudAgentRow` enum so the two surfaces show the same
 /// information per row.
 private enum MacCloudAgentRow {
     case devin(DevinAgentJob)
     case cursor(CursorAgentJob)
+    case codex(CodexAgentJob)
 
     var title: String {
         switch self {
@@ -174,6 +175,7 @@ private enum MacCloudAgentRow {
                 .replacingOccurrences(of: "\n", with: " ")
             if trimmed.count <= 80 { return trimmed }
             return String(trimmed.prefix(77)) + "\u{2026}"
+        case .codex(let job): return job.displayTitle
         }
     }
 
@@ -181,6 +183,7 @@ private enum MacCloudAgentRow {
         switch self {
         case .devin(let job): return job.status.capitalized
         case .cursor(let job): return job.status.capitalized
+        case .codex(let job): return job.state.rawValue.capitalized
         }
     }
 
@@ -188,6 +191,7 @@ private enum MacCloudAgentRow {
         switch self {
         case .devin(let job): return job.isTerminal
         case .cursor(let job): return job.isTerminal
+        case .codex(let job): return job.isTerminal
         }
     }
 
@@ -195,6 +199,8 @@ private enum MacCloudAgentRow {
         switch self {
         case .devin: return "Devin"
         case .cursor: return "Cursor"
+        case .codex(let job):
+            return "Codex · \(URL(fileURLWithPath: job.projectPath).lastPathComponent)"
         }
     }
 
@@ -214,6 +220,13 @@ private enum MacCloudAgentRow {
             case "finished": return .systemGray
             case "error":    return .systemRed
             default:         return .systemGray
+            }
+        case .codex(let job):
+            switch job.state {
+            case .queued, .running: return .systemGreen
+            case .waiting: return .systemYellow
+            case .completed, .cancelled: return .systemGray
+            case .failed: return .systemRed
             }
         }
     }
@@ -359,8 +372,13 @@ final class SubAgentInspectorWindowController: NSWindowController, NSTableViewDa
             conversationId == nil || job.conversationId == conversationId
         }
         for job in cursorJobs where !job.isTerminal { cloud.append(.cursor(job)) }
+        let codexJobs = CodexAgentService.shared.allJobs().filter { job in
+            conversationId == nil || job.conversationId == conversationId
+        }
+        for job in codexJobs where !job.isTerminal { cloud.append(.codex(job)) }
         for job in devinJobs where job.isTerminal { cloud.append(.devin(job)) }
         for job in cursorJobs where job.isTerminal { cloud.append(.cursor(job)) }
+        for job in codexJobs where job.isTerminal { cloud.append(.codex(job)) }
 
         var next: [InspectorRow] = []
         if !nativeAgents.isEmpty {
@@ -469,6 +487,8 @@ final class SubAgentInspectorWindowController: NSWindowController, NSTableViewDa
                let url = URL(string: urlString) {
                 NSWorkspace.shared.open(url)
             }
+        case .cloud(.codex(let job)):
+            CodexAgentDetailWindowController.show(agentId: job.id)
         }
     }
 }

--- a/LoopMac/VoiceLoopCoordinator.swift
+++ b/LoopMac/VoiceLoopCoordinator.swift
@@ -911,6 +911,9 @@ The current date and time is \(now).
         if CursorSkill.shared.handles(functionName: function.name) {
             CursorSkill.shared.handle(functionCall: function, completion: cont); return
         }
+        if CodexSkill.shared.handles(functionName: function.name) {
+            CodexSkill.shared.handle(functionCall: function, completion: cont); return
+        }
         if TwitterSkill.shared.handles(functionName: function.name) {
             TwitterSkill.shared.handle(functionCall: function, completion: cont); return
         }
@@ -966,6 +969,7 @@ The current date and time is \(now).
         if let s = SubAgentSkill.shared.statusText(for: call) { return s }
         if let s = DevinSkill.shared.statusText(for: call) { return s }
         if let s = CursorSkill.shared.statusText(for: call) { return s }
+        if let s = CodexSkill.shared.statusText(for: call) { return s }
         if let s = GoogleDriveSkill.shared.statusText(for: call) { return s }
         if let s = GoogleGmailSkill.shared.statusText(for: call) { return s }
         if let s = GoogleCalendarSkill.shared.statusText(for: call) { return s }

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ conversations.
   storage; the agent reads and writes its own long-term knowledge.
 - **Sub-agents** — spawn isolated agents for multi-step background tasks
   (`LoopIOS/SubAgents/`).
+- **Local Codex delegation (macOS)** — discover registered projects and fan
+  tasks out to Codex app-server agents with explicit read-only or workspace-
+  write access (`LoopMac/Codex/`).
 - **Voice pipeline** — push-to-talk capture, Deepgram STT, ElevenLabs/Apple
   TTS, and speech sanitization (`LoopIOS/SpeechPipeline/`, `LoopMac/`).
 - **Obsidian integration** — read/write an Obsidian vault through a
@@ -47,7 +50,7 @@ LoopIOS/               iOS app
   SpeechPipeline/       STT/TTS + sanitization
   Settings/KeyStore     Keychain-first credential store
   Data/                 conversation + memory persistence
-LoopMac/               macOS app (menu-bar, voice, terminal skill)
+LoopMac/               macOS app (menu-bar, voice, terminal + Codex skills)
 LoopShare/             iOS share extension
 LoopIOSShare/ LoopMacShare/   share-extension targets
 scripts/               Python helper/deploy utilities

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -203,6 +203,30 @@ does not become the main chat; when it finishes, a summary is posted back to
 the parent conversation. Research/general agents have runtime limits, while
 coding agents are designed to continue until completion or manual cancellation.
 
+### Local Codex agents on macOS
+
+The Mac target can also delegate repository work to the locally installed
+[Codex app server](https://developers.openai.com/codex/app-server). Loop owns
+one newline-delimited JSON connection to `codex app-server --listen stdio://`,
+performs the required `initialize` handshake, and maps each dispatched task to
+a Codex thread and turn.
+
+[`CodexSkill.swift`](../LoopMac/Codex/CodexSkill.swift) exposes project
+discovery, single-agent dispatch, three-project fan-out, listing, continuation,
+and cancellation to the main Loop model. [`CodexAgentService.swift`](../LoopMac/Codex/CodexAgentService.swift)
+persists the project/job registry and posts terminal results back into the
+conversation that launched them. The Mac Integrations window provides the same
+project registry and job details directly to the user.
+
+Safety is project-scoped: history-discovered and newly added projects default
+to `readOnly`; `workspaceWrite` must be enabled explicitly for that registered
+directory, only one write agent may run per project, and Loop never requests
+`dangerFullAccess`. App-server turns use `approvalPolicy: never`, so an action
+that cannot run inside the selected sandbox fails closed instead of leaving an
+unattended approval prompt. If Loop quits during a turn, the persisted job is
+marked interrupted at the next launch and can be continued on its existing
+Codex thread.
+
 ### Scheduled work
 
 [`BackgroundScheduler.swift`](../LoopIOS/Skills/Scheduler/BackgroundScheduler.swift)


### PR DESCRIPTION
## Summary
- add a long-lived Codex app-server stdio client with initialization, JSONL request routing, streamed lifecycle events, and unattended server-request handling
- add a persisted project registry and durable Codex job service with read-only defaults, explicit per-project write authorization, one-writer locking, continuation/cancellation, and exactly-once conversation post-back
- expose Loop model tools for project discovery, registration, single dispatch, three-project fan-out, agent listing, continuation, and cancellation
- integrate Codex jobs into the Mac agent pill/inspector and add a native Codex Projects panel under Settings → Integrations
- document the architecture and safety boundary

## Safety
- discovered projects default to read-only
- workspace-write must be explicitly enabled for a registered project
- filesystem root and the full home directory cannot be registered
- unrestricted filesystem access is never requested
- unattended approval and permission escalations are declined, so work fails closed instead of hanging

## Validation
- `git diff --cached --check`
- staged-patch Gitleaks scan: no leaks
- macOS Debug build (Loop_MacOS, code signing disabled)
- iOS Simulator Debug build (Loop_iOS, code signing disabled)
- live authenticated Codex CLI 0.145 app-server smoke test: initialize → ephemeral read-only thread/start → turn/start → streamed agent delta → turn/completed