### PR TITLE
Add DeepInfra provider with DeepSeek V4 Flash 0731

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,9 @@ EXA_API_KEY=
 # LLM (OpenAI)
 OPENAI_API_KEY=
 
+# LLM inference (DeepInfra)
+DEEPINFRA_API_KEY=
+
 # Cursor API (optional)
 CURSOR_API_KEY=
 

--- a/LoopIOS/AgentHarness/AgentHarness.swift
+++ b/LoopIOS/AgentHarness/AgentHarness.swift
@@ -552,6 +552,8 @@ final class AgentHarness {
             OpenAIChat.shared.chat(messages: rebuilt, tools: toolsToSend, modelIDOverride: modelIDOverride, modelStampOverride: modelStampOverride, onPartial: onPartial, completion: completion)
         case .fireworks:
             FireworksChat.shared.chat(messages: rebuilt, tools: toolsToSend, modelIDOverride: modelIDOverride, modelStampOverride: modelStampOverride, onPartial: onPartial, completion: completion)
+        case .deepInfra:
+            DeepInfraChat.shared.chat(messages: rebuilt, tools: toolsToSend, modelIDOverride: modelIDOverride, modelStampOverride: modelStampOverride, onPartial: onPartial, completion: completion)
         case .apple:
             // Unreachable — `.apple` returned via offlineRespond above. Kept
             // so the switch stays exhaustive if providers are added.

--- a/LoopIOS/Data/ConversationTitleService.swift
+++ b/LoopIOS/Data/ConversationTitleService.swift
@@ -212,6 +212,10 @@ final class ConversationTitleService {
                 return .fireworks(key: key)
             }
             return nil
+        case .deepInfra:
+            // DeepSeek V4 Flash is a reasoning model, so the tiny 32-token
+            // title request is better handled by an existing cheap fallback.
+            return nil
         }
     }
 

--- a/LoopIOS/Data/DeepInfraChat.swift
+++ b/LoopIOS/Data/DeepInfraChat.swift
@@ -1,0 +1,114 @@
+//
+//  DeepInfraChat.swift
+//  Loop
+//
+//  Direct client-side DeepInfra inference path. DeepInfra's chat endpoint
+//  is OpenAI-compatible, so message mapping, tool schemas, streaming, and
+//  tool-call assembly reuse the same helpers as OpenAIChat.
+//
+
+import Foundation
+
+final class DeepInfraChat {
+
+    static let shared = DeepInfraChat()
+    private init() {}
+
+    static let endpoint = URL(string: "https://api.deepinfra.com/v1/openai/chat/completions")!
+    static let defaultModelID = "deepseek-ai/DeepSeek-V4-Flash-0731"
+    static let maxTokens = 16_384
+
+    private lazy var streamingSessionDelegate = StreamingSessionDelegateRouter()
+    private lazy var streamingSession: URLSession = {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 120
+        config.timeoutIntervalForResource = 180
+        config.waitsForConnectivity = true
+        return URLSession(configuration: config,
+                          delegate: streamingSessionDelegate,
+                          delegateQueue: nil)
+    }()
+
+    static func requestBody(messages: [MessageStruct],
+                            tools: [[String: Any]]?,
+                            modelID: String) -> [String: Any] {
+        var body: [String: Any] = [
+            "model": modelID,
+            "messages": OpenAIChat.wireMessages(from: messages),
+            "max_tokens": maxTokens,
+            "stream": true,
+            "stream_options": ["include_usage": true],
+        ]
+        if let tools, !tools.isEmpty {
+            body["tools"] = tools
+            body["tool_choice"] = "auto"
+        }
+        return body
+    }
+
+    func chat(messages: [MessageStruct],
+              tools: [[String: Any]]? = nil,
+              modelIDOverride: String? = nil,
+              modelStampOverride: String? = nil,
+              onPartial: ((String) -> Void)? = nil,
+              completion: @escaping (MessageStruct?, Error?) -> Void) {
+        guard let apiKey = KeyStore.shared.value(for: .deepInfra),
+              !apiKey.isEmpty else {
+            completion(nil, Self.error(
+                "DeepInfra is selected but no DeepInfra key is set. Add DEEPINFRA_API_KEY in Settings ▸ Keys, or switch the model in Settings ▸ Model."))
+            return
+        }
+
+        let modelID = modelIDOverride
+            ?? ModelSelectionStore.current.apiModelID
+            ?? Self.defaultModelID
+        let body = Self.requestBody(messages: messages, tools: tools, modelID: modelID)
+
+        guard let payload = try? JSONSerialization.data(withJSONObject: body) else {
+            completion(nil, Self.error("Failed to encode the DeepInfra request body."))
+            return
+        }
+
+        var metrics = InferenceMetrics(provider: "DeepInfra",
+                                       model: modelID,
+                                       toolCount: (tools ?? []).count)
+        metrics.didBuildPayload(bytes: payload.count)
+
+        var request = URLRequest(url: Self.endpoint)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = payload
+        request.timeoutInterval = 120
+
+        metrics.willSendRequest()
+
+        let reader = SSEStreamReader(metrics: metrics, onDelta: onPartial) { result in
+            switch result {
+            case .success(let response):
+                let message = MessageStruct(
+                    role: "assistant",
+                    content: response.content,
+                    model: modelStampOverride ?? ModelSelectionStore.current.stampedMessageModel,
+                    functions: response.toolCalls,
+                    reasoningContent: response.reasoningContent,
+                    tokenUsage: response.usage,
+                    ttft: response.ttft)
+                completion(message, nil)
+            case .failure(let error):
+                completion(nil, Self.error(
+                    "DeepInfra streaming error: \(error.localizedDescription)"))
+            }
+        }
+
+        let task = streamingSession.dataTask(with: request)
+        streamingSessionDelegate.register(task: task, reader: reader)
+        LocalInferenceController.shared.track(task)
+        task.resume()
+    }
+
+    private static func error(_ message: String) -> NSError {
+        NSError(domain: "DeepInfraChat", code: -1,
+                userInfo: [NSLocalizedDescriptionKey: message])
+    }
+}

--- a/LoopIOS/Data/ModelSelection.swift
+++ b/LoopIOS/Data/ModelSelection.swift
@@ -5,7 +5,7 @@
 //  User-facing choice of which language model handles the next turn.
 //  Persisted in iCloud-KVS-backed UserDefaults so the pick survives
 //  relaunches and syncs across devices. Mac surfaces it as a grouped menu
-//  (Apple / OpenAI ▸ / Anthropic ▸ / Amazon Bedrock ▸); iOS reads the same store.
+//  (grouped by provider); iOS reads the same store.
 //
 //  AgentHarness reads `ModelSelectionStore.current` at dispatch time and
 //  routes by `.provider`:
@@ -14,6 +14,7 @@
 //    .anthropic → AnthropicChat (direct, user's ANTHROPIC_API_KEY)
 //    .bedrock   → BedrockChat   (direct, user's AWS_BEARER_TOKEN_BEDROCK)
 //    .fireworks → FireworksChat  (direct, user's FIREWORKS_API_KEY)
+//    .deepInfra → DeepInfraChat (direct, user's DEEPINFRA_API_KEY)
 //  Reachability still wins — offline always falls back to Apple, since the
 //  hosted providers can't work without a network. The selection is just the
 //  user's *preferred* model when the network is available.
@@ -50,6 +51,7 @@ enum ModelProvider: String, CaseIterable {
             (.bedrock, .bedrock),
             (.openAI, .openAI),
             (.fireworks, .fireworks),
+            (.deepInfra, .deepInfra),
         ]
         for (provider, key) in ranked {
             if KeyStore.shared.source(for: key) != .missing {
@@ -69,6 +71,7 @@ enum ModelProvider: String, CaseIterable {
     case anthropic
     case bedrock
     case fireworks
+    case deepInfra
 
     var displayName: String {
         switch self {
@@ -77,6 +80,7 @@ enum ModelProvider: String, CaseIterable {
         case .anthropic: return "Anthropic"
         case .bedrock:   return "Amazon Bedrock"
         case .fireworks: return "Fireworks"
+        case .deepInfra:  return "DeepInfra"
         }
     }
 }
@@ -109,6 +113,9 @@ enum ModelSelection: String, CaseIterable {
     case fireworksGLM52  = "fireworksGLM52"
     case fireworksDeepSeekV4Flash0731 = "fireworksDeepSeekV4Flash0731"
 
+    // DeepInfra — DeepSeek models served via DeepInfra inference.
+    case deepInfraDeepSeekV4Flash0731 = "deepInfraDeepSeekV4Flash0731"
+
     var provider: ModelProvider {
         switch self {
         case .appleFoundation:
@@ -122,6 +129,8 @@ enum ModelSelection: String, CaseIterable {
         case .fireworksKimiK3, .fireworksKimiK26, .fireworksGLM52,
              .fireworksDeepSeekV4Flash0731:
             return .fireworks
+        case .deepInfraDeepSeekV4Flash0731:
+            return .deepInfra
         }
     }
 
@@ -143,6 +152,7 @@ enum ModelSelection: String, CaseIterable {
         case .fireworksKimiK26: return "Kimi K2.6"
         case .fireworksGLM52:  return "GLM 5.2"
         case .fireworksDeepSeekV4Flash0731: return "DeepSeek-V4-Flash-0731"
+        case .deepInfraDeepSeekV4Flash0731: return "DeepSeek V4 Flash 0731"
         }
     }
 
@@ -168,6 +178,7 @@ enum ModelSelection: String, CaseIterable {
         case .fireworksGLM52:  return "accounts/fireworks/models/glm-5p2"
         case .fireworksDeepSeekV4Flash0731:
             return "accounts/fireworks/models/deepseek-v4-flash-0731"
+        case .deepInfraDeepSeekV4Flash0731: return "deepseek-ai/DeepSeek-V4-Flash-0731"
         }
     }
 
@@ -177,6 +188,7 @@ enum ModelSelection: String, CaseIterable {
         switch provider {
         case .apple: return "Apple LLM"
         case .bedrock: return "\(displayName) via Bedrock"
+        case .deepInfra: return "\(displayName) via DeepInfra"
         default:     return displayName
         }
     }
@@ -201,6 +213,7 @@ enum ModelSelection: String, CaseIterable {
         case .fireworksKimiK26: return 131_072
         case .fireworksGLM52:  return 1_048_576
         case .fireworksDeepSeekV4Flash0731: return 1_064_960
+        case .deepInfraDeepSeekV4Flash0731: return 1_048_576
         }
     }
 
@@ -227,6 +240,7 @@ enum ModelSelection: String, CaseIterable {
         case .anthropic: return .anthropic
         case .bedrock:   return .bedrock
         case .fireworks: return .fireworks
+        case .deepInfra:  return .deepInfra
         }
     }
 
@@ -254,6 +268,8 @@ enum ModelSelection: String, CaseIterable {
             // DeepSeek-V4-Flash on Fireworks is text-only — image turns fall
             // back to Kimi.
             return false
+        case .deepInfraDeepSeekV4Flash0731:
+            return false
         }
     }
 
@@ -275,7 +291,7 @@ enum ModelSelection: String, CaseIterable {
         if let sameProvider = models(for: provider).first(where: { $0.supportsVision && $0.isUsable }) {
             return sameProvider
         }
-        for other in [ModelProvider.anthropic, .bedrock, .openAI, .fireworks] where other != provider {
+        for other in [ModelProvider.anthropic, .bedrock, .openAI, .fireworks, .deepInfra] where other != provider {
             if let model = models(for: other).first(where: { $0.supportsVision && $0.isUsable }) {
                 return model
             }

--- a/LoopIOS/Data/SSEStreamReader.swift
+++ b/LoopIOS/Data/SSEStreamReader.swift
@@ -7,7 +7,8 @@
 //  response and incrementally assembles content deltas and tool-call
 //  fragments into a final `MessageStruct`.
 //
-//  Used by OpenAIChat and FireworksChat (both use the same SSE wire format).
+//  Used by OpenAIChat, FireworksChat, and DeepInfraChat (all use the same
+//  SSE wire format).
 //  Anthropic uses a different event schema — see AnthropicChat for its
 //  streaming path.
 //

--- a/LoopIOS/Data/VisionSummaryService.swift
+++ b/LoopIOS/Data/VisionSummaryService.swift
@@ -119,6 +119,10 @@ final class VisionSummaryService {
         case .fireworks:
             FireworksChat.shared.chat(messages: [probe], tools: nil,
                                       modelIDOverride: target.modelID, completion: handle)
+        case .deepInfra:
+            // The current DeepInfra model is text-only, so visionTarget()
+            // never returns this provider.
+            finishWithOCRFallback(attachment, conversationId: conversationId)
         case .apple:
             // visionTarget() only ever returns hosted providers; keep the
             // switch exhaustive.

--- a/LoopIOS/Info.plist
+++ b/LoopIOS/Info.plist
@@ -39,6 +39,8 @@
 	<string>$(BEDROCK_AWS_REGION)</string>
 	<key>FIREWORKS_API_KEY</key>
 	<string>$(FIREWORKS_API_KEY)</string>
+	<key>DEEPINFRA_API_KEY</key>
+	<string>$(DEEPINFRA_API_KEY)</string>
 	<key>CURSOR_API_KEY</key>
 	<string>$(CURSOR_API_KEY)</string>
 	<key>OBSIDIAN_API_KEY</key>

--- a/LoopIOS/Onboarding/OnboardingCoordinator.swift
+++ b/LoopIOS/Onboarding/OnboardingCoordinator.swift
@@ -128,6 +128,7 @@ final class OnboardingCoordinator {
         static let modelBedrock      = "model.bedrock"
         static let modelOpenAI       = "model.openai"
         static let modelFireworks    = "model.fireworks"
+        static let modelDeepInfra    = "model.deepinfra"
         static let skipKey           = "key.skip"
         static let connectNotion     = "integration.notion"
         static let connectGitHub     = "integration.github"
@@ -304,6 +305,12 @@ final class OnboardingCoordinator {
                 pendingKeyProvider = .fireworks
                 selectModel(for: .fireworks)
                 advanceAfterModelPick(.fireworks)
+            } else if lower.contains("deepinfra") || lower.contains("deepseek") {
+                let verb = KeyStore.shared.source(for: .deepInfra) != .missing ? "Use" : "Add"
+                commitAnswer(echo: "\(verb) DeepInfra")
+                pendingKeyProvider = .deepInfra
+                selectModel(for: .deepInfra)
+                advanceAfterModelPick(.deepInfra)
             } else {
                 echoUser(trimmed)
             }
@@ -492,6 +499,13 @@ final class OnboardingCoordinator {
             pendingKeyProvider = .fireworks
             selectModel(for: .fireworks)
             advanceAfterModelPick(.fireworks)
+
+        case (.greeting, ChipId.modelDeepInfra),
+             (.modelChoice, ChipId.modelDeepInfra):
+            commitAnswer(echo: label)
+            pendingKeyProvider = .deepInfra
+            selectModel(for: .deepInfra)
+            advanceAfterModelPick(.deepInfra)
 
         case (.keyPaste, ChipId.skipKey):
             commitAnswer(echo: label)
@@ -684,6 +698,8 @@ final class OnboardingCoordinator {
                 ? "Use Bedrock" : "Add Bedrock"
             let fireworksLabel = KeyStore.shared.source(for: .fireworks) != .missing
                 ? "Use Fireworks" : "Add Fireworks"
+            let deepInfraLabel = KeyStore.shared.source(for: .deepInfra) != .missing
+                ? "Use DeepInfra" : "Add DeepInfra"
             let greetingText: String
             if ModelProvider.hasAnyProviderKey {
                 greetingText = "Nice to meet you! **Let's get set up with this Harness.**\n\nI'm running inference with \(current.displayName). Want to try something else? Tap or type below to plug in a key."
@@ -712,6 +728,9 @@ final class OnboardingCoordinator {
             }
             if currentProvider != .fireworks {
                 chips.append(.init(id: ChipId.modelFireworks, label: fireworksLabel))
+            }
+            if currentProvider != .deepInfra {
+                chips.append(.init(id: ChipId.modelDeepInfra, label: deepInfraLabel))
             }
 
             return assistantMessage(
@@ -910,7 +929,7 @@ final class OnboardingCoordinator {
 
     /// Set the flagship model for the given provider as the active selection
     /// so the next message routes through it. Called when the user picks a
-    /// provider chip (Claude/OpenAI/Bedrock/Fireworks) AND again when they actually
+    /// provider chip (Claude/OpenAI/Bedrock/Fireworks/DeepInfra) AND again when they actually
     /// paste a key — both writes are idempotent. Mirrors what ModelPickerVC
     /// does.
     private func selectModel(for key: KeyStore.Key) {
@@ -920,6 +939,7 @@ final class OnboardingCoordinator {
         case .bedrock:   selection = .bedrockOpus5
         case .openAI:    selection = .gpt55
         case .fireworks: selection = .fireworksKimiK26
+        case .deepInfra:  selection = .deepInfraDeepSeekV4Flash0731
         default:         selection = nil
         }
         if let s = selection {

--- a/LoopIOS/Runner/VMAgentRuntime.swift
+++ b/LoopIOS/Runner/VMAgentRuntime.swift
@@ -42,12 +42,14 @@ enum VMAgentRuntime {
         case .bedrock:   if let k = key(.bedrock),   let m = sel.apiModelID { return ("bedrock", m, k, sel.displayName) }
         case .openAI:    if let k = key(.openAI),    let m = sel.apiModelID { return ("openai", m, k, sel.displayName) }
         case .fireworks: if let k = key(.fireworks), let m = sel.apiModelID { return ("fireworks", m, k, sel.displayName) }
+        case .deepInfra: if let k = key(.deepInfra), let m = sel.apiModelID { return ("deepinfra", m, k, sel.displayName) }
         case .apple: break
         }
         if let k = key(.openAI)    { return ("openai", "gpt-4o", k, "GPT-4o") }
         if let k = key(.anthropic) { return ("anthropic", "claude-sonnet-4-6", k, "Claude Sonnet 4.6") }
         if let k = key(.bedrock)   { return ("bedrock", "anthropic.claude-opus-4-7", k, "Claude Opus 4.7") }
         if let k = key(.fireworks) { return ("fireworks", "accounts/fireworks/models/kimi-k2p6", k, "Kimi K2.6") }
+        if let k = key(.deepInfra) { return ("deepinfra", "deepseek-ai/DeepSeek-V4-Flash-0731", k, "DeepSeek V4 Flash 0731") }
         return nil
     }
 
@@ -217,9 +219,12 @@ try:
         base = "https://bedrock-mantle.%s.api.aws/anthropic/v1/messages" % region
         text = run_anthropic(key, model, system, conv, base)
     else:
-        base = ("https://api.fireworks.ai/inference/v1/chat/completions"
-                if provider == "fireworks"
-                else "https://api.openai.com/v1/chat/completions")
+        if provider == "fireworks":
+            base = "https://api.fireworks.ai/inference/v1/chat/completions"
+        elif provider == "deepinfra":
+            base = "https://api.deepinfra.com/v1/openai/chat/completions"
+        else:
+            base = "https://api.openai.com/v1/chat/completions"
         text = run_openai(base, key, model, msgs)
 except urllib.error.HTTPError as e:
     err = "HTTP %s: %s" % (e.code, e.read().decode("utf-8", "ignore")[:200])

--- a/LoopIOS/Settings/KeyStore.swift
+++ b/LoopIOS/Settings/KeyStore.swift
@@ -31,6 +31,7 @@ final class KeyStore {
         case bedrock        = "AWS_BEARER_TOKEN_BEDROCK"
         case bedrockRegion  = "BEDROCK_AWS_REGION"
         case fireworks      = "FIREWORKS_API_KEY"
+        case deepInfra       = "DEEPINFRA_API_KEY"
         case cursor         = "CURSOR_API_KEY"
         case obsidianAPI    = "OBSIDIAN_API_KEY"
         case obsidianBaseURL = "OBSIDIAN_BASE_URL"
@@ -65,6 +66,7 @@ final class KeyStore {
             case .bedrock:                return "Amazon Bedrock API Key"
             case .bedrockRegion:          return "AWS Region"
             case .fireworks:              return "Fireworks"
+            case .deepInfra:               return "DeepInfra"
             case .cursor:                 return "Cursor"
             case .obsidianAPI:            return "Obsidian API Key"
             case .obsidianBaseURL:        return "Obsidian Base URL"
@@ -101,6 +103,7 @@ final class KeyStore {
             case .bedrock:                return "Claude Opus models through Amazon Bedrock"
             case .bedrockRegion:          return "Optional Bedrock Mantle region · defaults to us-east-1"
             case .fireworks:              return "Fireworks inference platform (Kimi K2.6, etc.)"
+            case .deepInfra:               return "DeepInfra inference (DeepSeek V4 Flash 0731)"
             case .cursor:                 return "Cursor agent integration"
             case .obsidianAPI:            return "Bearer token for the Obsidian relay"
             case .obsidianBaseURL:        return "Public URL of the Obsidian relay"
@@ -133,7 +136,7 @@ final class KeyStore {
     /// second). Adding a new key means: (a) add the `Key` case above, (b)
     /// either add a new `Service` case here or extend an existing one's `keys`.
     enum Service: String, CaseIterable {
-        case openAI, anthropic, bedrock, fireworks, deepgram, elevenLabs, exa
+        case openAI, anthropic, bedrock, fireworks, deepInfra, deepgram, elevenLabs, exa
         case cursor, devin
         case github, slack, notion, obsidian
         case twitter
@@ -149,6 +152,7 @@ final class KeyStore {
             case .anthropic:  return "Anthropic"
             case .bedrock:    return "Amazon Bedrock"
             case .fireworks:  return "Fireworks"
+            case .deepInfra:   return "DeepInfra"
             case .deepgram:   return "Deepgram"
             case .elevenLabs: return "ElevenLabs"
             case .exa:        return "Exa"
@@ -176,6 +180,7 @@ final class KeyStore {
             case .anthropic:  return "Claude models for the agent"
             case .bedrock:    return "Claude Opus models via Bedrock Mantle using your Amazon Bedrock API key"
             case .fireworks:  return "Fireworks inference platform — run Kimi K2.6 and other open models via Fireworks"
+            case .deepInfra:   return "Run DeepSeek V4 Flash 0731 and other open models via DeepInfra"
             case .deepgram:   return "Streaming STT + Aura TTS"
             case .elevenLabs: return "Expressive TTS voices"
             case .exa:        return "Web search + answer skill"
@@ -204,6 +209,7 @@ final class KeyStore {
             case .anthropic:  return [.anthropic]
             case .bedrock:    return [.bedrock, .bedrockRegion]
             case .fireworks:  return [.fireworks]
+            case .deepInfra:   return [.deepInfra]
             case .deepgram:   return [.deepgram]
             case .elevenLabs: return [.elevenLabs]
             case .exa:        return [.exa]

--- a/LoopIOS/Settings/ModelPickerVC.swift
+++ b/LoopIOS/Settings/ModelPickerVC.swift
@@ -124,6 +124,10 @@ final class ModelPickerVC: UIViewController {
             return keyConfigured(.fireworks)
                 ? "Uses your Fireworks API key."
                 : "Needs a Fireworks API key. Add one in Settings ▸ Keys."
+        case .deepInfra:
+            return keyConfigured(.deepInfra)
+                ? "Uses your DeepInfra API key."
+                : "Needs a DeepInfra API key. Add one in Settings ▸ Keys."
         }
     }
 }

--- a/LoopIOS/Skills/Integrations/IntegrationSkill.swift
+++ b/LoopIOS/Skills/Integrations/IntegrationSkill.swift
@@ -135,7 +135,7 @@ Tips:
                     "properties": [
                         "name": [
                             "type": "string",
-                            "description": "Key identifier. Aliases accepted: openai, deepgram, elevenlabs, exa, cursor, obsidian_api, obsidian_base_url, obsidian_vault_name."
+                            "description": "Key identifier. Aliases accepted: openai, deepinfra, deepgram, elevenlabs, exa, cursor, obsidian_api, obsidian_base_url, obsidian_vault_name."
                         ],
                         "value": [
                             "type": "string",
@@ -494,6 +494,7 @@ Tips:
         case .bedrock:                return "bedrock"
         case .bedrockRegion:          return "bedrock_region"
         case .fireworks:              return "fireworks"
+        case .deepInfra:               return "deepinfra"
         case .cursor:                 return "cursor"
         case .obsidianAPI:            return "obsidian_api"
         case .obsidianBaseURL:        return "obsidian_base_url"
@@ -529,7 +530,7 @@ Tips:
             completion(Self.functionMessage(name: toolName, payload: [
                 "error": "unknown_key",
                 "name": name,
-                "hint": "Aliases accepted: openai, deepgram, elevenlabs, exa, cursor, obsidian_api, obsidian_base_url, obsidian_vault_name."
+                "hint": "Aliases accepted: openai, deepinfra, deepgram, elevenlabs, exa, cursor, obsidian_api, obsidian_base_url, obsidian_vault_name."
             ]))
             return
         }
@@ -560,6 +561,7 @@ Tips:
         case "bedrock", "amazon_bedrock", "amazon bedrock": return .bedrock
         case "bedrock_region", "bedrock region", "aws_region": return .bedrockRegion
         case "fireworks":                                     return .fireworks
+        case "deepinfra", "deep_infra", "deep infra":        return .deepInfra
         case "deepgram":                                      return .deepgram
         case "elevenlabs", "eleven_labs", "eleven labs":      return .elevenLabs
         case "exa":                                           return .exa

--- a/LoopIOSTests/DeepInfraChatTests.swift
+++ b/LoopIOSTests/DeepInfraChatTests.swift
@@ -1,0 +1,57 @@
+//
+//  DeepInfraChatTests.swift
+//  LoopIOSTests
+//
+
+import XCTest
+@testable import Loop
+
+final class DeepInfraChatTests: XCTestCase {
+
+    func testDeepSeekModelSelectionUsesDeepInfraContract() {
+        let model = ModelSelection.deepInfraDeepSeekV4Flash0731
+
+        XCTAssertEqual(model.provider, .deepInfra)
+        XCTAssertEqual(model.requiredKey, .deepInfra)
+        XCTAssertEqual(model.displayName, "DeepSeek V4 Flash 0731")
+        XCTAssertEqual(model.apiModelID, "deepseek-ai/DeepSeek-V4-Flash-0731")
+        XCTAssertEqual(model.contextWindowSize, 1_048_576)
+        XCTAssertFalse(model.supportsVision)
+        XCTAssertEqual(model.stampedMessageModel, "DeepSeek V4 Flash 0731 via DeepInfra")
+        XCTAssertEqual(ModelSelection.contextWindowSize(forStamp: model.stampedMessageModel),
+                       1_048_576)
+    }
+
+    func testRequestBodyUsesDeepInfraChatCompletionsShape() throws {
+        let messages = [
+            MessageStruct(role: "system", content: "Be concise."),
+            MessageStruct(role: "user", content: "Check the weather."),
+        ]
+        let tools: [[String: Any]] = [[
+            "type": "function",
+            "function": [
+                "name": "weather",
+                "description": "Get weather",
+                "parameters": [
+                    "type": "object",
+                    "properties": ["city": ["type": "string"]],
+                ] as [String: Any],
+            ] as [String: Any],
+        ]]
+
+        let body = DeepInfraChat.requestBody(
+            messages: messages,
+            tools: tools,
+            modelID: DeepInfraChat.defaultModelID)
+
+        XCTAssertEqual(DeepInfraChat.endpoint.absoluteString,
+                       "https://api.deepinfra.com/v1/openai/chat/completions")
+        XCTAssertEqual(body["model"] as? String,
+                       "deepseek-ai/DeepSeek-V4-Flash-0731")
+        XCTAssertEqual(body["max_tokens"] as? Int, 16_384)
+        XCTAssertEqual(body["stream"] as? Bool, true)
+        XCTAssertEqual(body["tool_choice"] as? String, "auto")
+        XCTAssertNotNil(body["messages"] as? [[String: Any]])
+        XCTAssertNotNil(body["tools"] as? [[String: Any]])
+    }
+}

--- a/LoopMac/Info.plist
+++ b/LoopMac/Info.plist
@@ -59,6 +59,8 @@
 	<string>$(BEDROCK_AWS_REGION)</string>
 	<key>FIREWORKS_API_KEY</key>
 	<string>$(FIREWORKS_API_KEY)</string>
+	<key>DEEPINFRA_API_KEY</key>
+	<string>$(DEEPINFRA_API_KEY)</string>
 	<key>OBSIDIAN_API_KEY</key>
 	<string>$(OBSIDIAN_API_KEY)</string>
 	<key>OBSIDIAN_BASE_URL</key>

--- a/LoopMac/LoopMacApp.swift
+++ b/LoopMac/LoopMacApp.swift
@@ -648,8 +648,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return item
         }
 
-        // One section per provider, in `ModelProvider` order (Apple, OpenAI,
-        // Anthropic). Single-model providers (Apple) render as a flat item;
+        // One section per provider, in `ModelProvider` order. Single-model
+        // providers (Apple, DeepInfra) render as a flat item;
         // multi-model providers get a submenu, with the checkmark mirrored
         // onto the parent so the active provider shows without opening it.
         for provider in ModelProvider.allCases {

--- a/Secrets.xcconfig.example
+++ b/Secrets.xcconfig.example
@@ -32,6 +32,8 @@ ANTHROPIC_API_KEY =
 // Fireworks inference platform — run Kimi K2.6 and other open models.
 // Set this and Kimi K2.6 (via Fireworks) becomes the default model on first launch.
 FIREWORKS_API_KEY =
+// DeepInfra inference platform — run DeepSeek V4 Flash 0731.
+DEEPINFRA_API_KEY =
 CURSOR_API_KEY =
 OBSIDIAN_API_KEY =
 OBSIDIAN_BASE_URL =

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -20,7 +20,7 @@ flowchart LR
 
     Workspace["Workspace<br/>SOUL, USER, MEMORY,<br/>AGENTS, tools, files"] --> Harness
     Keys["Keychain<br/>user-owned API keys"] --> Providers
-    Harness --> Providers["Model provider<br/>OpenAI, Anthropic, Amazon Bedrock,<br/>Fireworks, or Apple on-device"]
+    Harness --> Providers["Model provider<br/>OpenAI, Anthropic, Amazon Bedrock,<br/>Fireworks, DeepInfra, or Apple on-device"]
 
     Providers -->|"final text"| Surface
     Providers -->|"tool calls"| Dispatcher["SkillDispatcher"]
@@ -138,7 +138,7 @@ In more concrete terms:
    not carry the full catalog. Ambiguous requests can still receive the broad
    set.
 4. **Choose a model route.** Online requests go directly to the selected
-   OpenAI, Anthropic, or Fireworks client. Apple Foundation Models are used
+   OpenAI, Anthropic, Amazon Bedrock, Fireworks, or DeepInfra client. Apple Foundation Models are used
    when selected or when the device is offline and the on-device model is
    available. If an attachment needs vision and the chosen model cannot see
    images, that turn can be routed to a vision-capable model.


### PR DESCRIPTION
## Summary

- add DeepInfra as an OpenAI-compatible model provider with secure `DEEPINFRA_API_KEY` storage
- add `deepseek-ai/DeepSeek-V4-Flash-0731` to iOS and macOS model selection and onboarding
- route foreground agent turns and background VM execution through DeepInfra's chat-completions endpoint
- add request/model contract coverage plus configuration examples and architecture documentation

## User impact

Users can add a DeepInfra API key in Settings and select DeepSeek V4 Flash 0731 on iOS or macOS. Streaming responses, usage metrics, and tool calls reuse the existing OpenAI-compatible pipeline.

## Validation

- iOS simulator Debug build: passed
- macOS Debug build: passed
- iOS and macOS Info.plist lint: passed
- embedded VM Python runner syntax: passed
- `git diff --check`: passed
- Gitleaks working-tree scan: passed, no findings
- XCTest contract file added; not executed because the repository's `Loop_iOS` scheme is not configured for the test action
- authenticated DeepInfra request not run; live behavior should be checked with a rotated credential
